### PR TITLE
Added list of criteria to be considered while adding tool on Tech radar

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,22 @@
 # Contribution guidelines
 
+## A list of criteria for a tool or service to be added in the TechRadar
+
+1. The tool is designed to measure and/or improve a software quality dimension.
+
+2. The tool automates the measurement and/or improvement of software quality.
+
+3. The tool is frequently used on research software and being actively maintained.
+
+4. The tool enables the software it is used on to follow relevant research community standards and best practices.
+
 ## How to contribute 
 
 **Note:** This section is work in progress
 
 You can add tools and modify the technology watch content by opening a pull request:
   
-1. Open an issue with the type of tools you would like to see in Technology Watch.
+1. Open an issue with the type of tools you would like to see in Technology Watch satisfying a list of criteria.
   
 2. When you and the editor have agreed on what you will do, you can edit on the GitHub repository by clicking on the pencil icon.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 ## A list of criteria for a tool or service to be added in the TechRadar
 
-1. The tool has been designed with the intent of measuring/improving software quality and it does measure or improve software quality.
+1. The tool/service has been designed with the intent of measuring/improving software quality, and it does measure or improve software quality.
 
-2. The tool is frequently used on research software and being actively maintained.
+2. The tool/service is frequently used on research software and is being actively maintained.
 
-3. The tool enables the software it is used on to follow relevant research community standards and best practices.
+3. The tool/service enables the software it is used on to follow relevant research community standards and best practices.
 
-4. The tool has capabilities to analyse and improve software quality throughout the research software lifecycle, from development to long-term sustainability.
+4. The tool/service has capabilities to analyse and improve software quality throughout the research software lifecycle, from development to long-term sustainability.
 
 
 ## How to contribute 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,14 @@
 
 ## A list of criteria for a tool or service to be added in the TechRadar
 
-1. The tool is designed to measure and/or improve a software quality.
+1. The tool has been designed with the intent of measuring/improving software quality and it does measure or improve software quality.
 
-2. The tool automates the measurement and/or improvement of software quality.
+2. The tool is frequently used on research software and being actively maintained.
 
-3. The tool is frequently used on research software and being actively maintained.
+3. The tool enables the software it is used on to follow relevant research community standards and best practices.
 
-4. The tool enables the software it is used on to follow relevant research community standards and best practices.
+4. The tool has capabilities to analyse and improve software quality throughout the research software lifecycle, from development to long-term sustainability.
+
 
 ## How to contribute 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## A list of criteria for a tool or service to be added in the TechRadar
 
-1. The tool is designed to measure and/or improve a software quality dimension.
+1. The tool is designed to measure and/or improve a software quality.
 
 2. The tool automates the measurement and/or improvement of software quality.
 
@@ -14,9 +14,9 @@
 
 **Note:** This section is work in progress
 
-You can add tools and modify the technology watch content by opening a pull request:
+You can add tools and modify the TechRadar content by opening a pull request:
   
-1. Open an issue with the type of tools you would like to see in Technology Watch satisfying a list of criteria.
+1. Open a pull request suggesting tools you would like to see in TechRadar satisfying a list of criteria.
   
 2. When you and the editor have agreed on what you will do, you can edit on the GitHub repository by clicking on the pencil icon.
 


### PR DESCRIPTION
1. Added a list of criteria for a tool or service to be added in TechRadar.
2. These list is obtained and decided within T3.1 involved members as well as  from slido poll inputs run within WP3 involved members.
3. A dedicated section is added in Contributing.md file

Fixes issue #17