### PR TITLE
Corrected schema for already present tools

### DIFF
--- a/about.md
+++ b/about.md
@@ -26,14 +26,9 @@ The tools in the technology watch are from EVERSE work package 3 collected tools
 
 #### Each of the items is classified in one of these rings:
 
-- **analysis code:** We wholeheartedly recommend this technology. It has been extensively used in many teams
-  for an extended period, proving its stability and utility.
-- **prototype tools:** We have successfully implemented this technology and suggest taking a closer look at it
-  in this category. The aim here is to scrutinize these items more closely with the intention of
-  elevating them to the 'Adopt' level.
-- **research infrastructure software:** We have experimented with this technology and find it promising. We recommend
-  exploring these items when you encounter a specific need for the technology in your project.
-
+- **analysis code:** 
+- **prototype tools:** 
+- **research infrastructure software:** 
 
 ### Contributing to the EVERSE Technology Radar
 

--- a/data/software-tools/bandit.json
+++ b/data/software-tools/bandit.json
@@ -8,16 +8,15 @@
   "schema:name": "bandit",
   "schema:description": "Bandit is a tool designed to find common security issues in Python code.",
   "schema:url": "https://github.com/PyCQA/bandit",
-  "schema:isAccessibleForFree": "free",
+  "schema:isAccessibleForFree": true,
   "rs:hasQualityDimension": {
     "@id": "rs:Sustainability",
     "@type": "@id"
   },
-  "rs:howToUse": [
-    "online-service"
-  ],
+  "rs:howToUse": ["CI/CD", "command-line"],
   "schema:license": {
     "@id": "https://opensource.org/licenses/Apache-2.0",
     "@type": "@id"
-  }
+  },
+  "schema:applicationCategory": { "id": "rs:AnalysisCode", "type": "@id"}
 }

--- a/data/software-tools/bandit.json
+++ b/data/software-tools/bandit.json
@@ -14,6 +14,7 @@
     "@type": "@id"
   },
   "rs:howToUse": ["CI/CD", "command-line"],
+  "rs:appliesToProgrammingLanguage": ["Python"],
   "schema:license": {
     "@id": "https://opensource.org/licenses/Apache-2.0",
     "@type": "@id"

--- a/data/software-tools/bandit.json
+++ b/data/software-tools/bandit.json
@@ -19,5 +19,5 @@
     "@id": "https://opensource.org/licenses/Apache-2.0",
     "@type": "@id"
   },
-  "schema:applicationCategory": { "id": "rs:AnalysisCode", "type": "@id"}
+  "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"}
 }

--- a/data/software-tools/bearer.json
+++ b/data/software-tools/bearer.json
@@ -13,5 +13,5 @@
     "rs:howToUse": ["online-service"],
     "rs:appliesToProgrammingLanguage": ["JavaScript/TypeScript", "Ruby", "PHP", "Java", "Go", "Python"],
     "schema:license": { "@id": "https://spdx.org/licenses/Elastic-2.0", "@type": "@id"},
-    "schema:applicationCategory": { "id": "rs:AnalysisCode", "type": "@id"}
+    "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"}
   }

--- a/data/software-tools/bearer.json
+++ b/data/software-tools/bearer.json
@@ -12,6 +12,6 @@
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["online-service"],
     "rs:appliesToProgrammingLanguage": ["JavaScript/TypeScript", "Ruby", "PHP", "Java", "Go", "Python"],
-    "schema:license": { "@id": "https://spdx.org/licenses/Elastic-2.0.html", "@type": "@id"},
+    "schema:license": { "@id": "https://spdx.org/licenses/Elastic-2.0", "@type": "@id"},
     "schema:applicationCategory": { "id": "rs:AnalysisCode", "type": "@id"}
   }

--- a/data/software-tools/bearer.json
+++ b/data/software-tools/bearer.json
@@ -11,6 +11,7 @@
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["online-service"],
+    "rs:appliesToProgrammingLanguage": ["JavaScript/TypeScript", "Ruby", "PHP", "Java", "Go", "Python"],
     "schema:license": { "@id": "https://spdx.org/licenses/Elastic-2.0.html", "@type": "@id"},
     "schema:applicationCategory": { "id": "rs:AnalysisCode", "type": "@id"}
   }

--- a/data/software-tools/cffinit_generator.json
+++ b/data/software-tools/cffinit_generator.json
@@ -10,6 +10,7 @@
     "schema:url": "https://citation-file-format.github.io/cff-initializer-javascript/#/",
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
+    "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id"}
       

--- a/data/software-tools/cffinit_generator.json
+++ b/data/software-tools/cffinit_generator.json
@@ -12,6 +12,6 @@
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
     "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
-    "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0", "@type": "@id"}
       
   }

--- a/data/software-tools/cffinit_generator.json
+++ b/data/software-tools/cffinit_generator.json
@@ -10,7 +10,7 @@
     "schema:url": "https://citation-file-format.github.io/cff-initializer-javascript/#/",
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
-    "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0", "@type": "@id"}
       

--- a/data/software-tools/codemeta_generator.json
+++ b/data/software-tools/codemeta_generator.json
@@ -12,6 +12,6 @@
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
     "rs:howToUse": ["CI/CD","command-line"],
-    "schema:license": { "@id": "https://www.gnu.org/licenses/agpl-3.0.html", "@type": "@id"}
+    "schema:license": { "@id": "https://www.gnu.org/licenses/agpl-3.0", "@type": "@id"}
       
   }

--- a/data/software-tools/codemeta_generator.json
+++ b/data/software-tools/codemeta_generator.json
@@ -10,7 +10,7 @@
     "schema:url": "https://codemeta.github.io/codemeta-generator",
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
-    "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:howToUse": ["CI/CD","command-line"],
     "schema:license": { "@id": "https://www.gnu.org/licenses/agpl-3.0", "@type": "@id"}
       

--- a/data/software-tools/codemeta_generator.json
+++ b/data/software-tools/codemeta_generator.json
@@ -10,6 +10,7 @@
     "schema:url": "https://codemeta.github.io/codemeta-generator",
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
+    "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
     "rs:howToUse": ["CI/CD","command-line"],
     "schema:license": { "@id": "https://www.gnu.org/licenses/agpl-3.0.html", "@type": "@id"}
       

--- a/data/software-tools/doxygen.json
+++ b/data/software-tools/doxygen.json
@@ -8,7 +8,7 @@
     "schema:name": "doxygen",
     "schema:description": "Doxygen is a documentation generator for annotated source code. It helps developers automatically produce software documentation from the comments and structure of their code. Supports languages like C, C++, Java, Python, PHP, Fortran, etc",
     "schema:url": "https://www.doxygen.nl/",
-    "schema:applicationCategory": { "id": "rs:AnalysisCode", "type": "@id"},
+    "schema:applicationCategory": { "@id": "rs:AnalysisCode", "type": "@id"},
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
     "rs:howToUse": ["CI/CD","command-line"],

--- a/data/software-tools/doxygen.json
+++ b/data/software-tools/doxygen.json
@@ -12,5 +12,6 @@
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
     "rs:howToUse": ["CI/CD","command-line"],
+    "rs:appliesToProgrammingLanguage": ["C++", "C", "Python", "PHP", "Java", "C#", "Objective-C", "Fortran", "VHDL", "Splice", "IDL", "Lex"],
     "schema:license": { "@id": "https://spdx.org/licenses/GPL-2.0-only.html", "@type": "@id"}      
   }

--- a/data/software-tools/doxygen.json
+++ b/data/software-tools/doxygen.json
@@ -13,5 +13,5 @@
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
     "rs:howToUse": ["CI/CD","command-line"],
     "rs:appliesToProgrammingLanguage": ["C++", "C", "Python", "PHP", "Java", "C#", "Objective-C", "Fortran", "VHDL", "Splice", "IDL", "Lex"],
-    "schema:license": { "@id": "https://spdx.org/licenses/GPL-2.0-only.html", "@type": "@id"}      
+    "schema:license": { "@id": "https://spdx.org/licenses/GPL-2.0-only", "@type": "@id"}      
   }

--- a/data/software-tools/dvc.json
+++ b/data/software-tools/dvc.json
@@ -12,5 +12,5 @@
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD","command-line"],
-    "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id"}      
+    "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0", "@type": "@id"}      
   }

--- a/data/software-tools/dvc.json
+++ b/data/software-tools/dvc.json
@@ -8,10 +8,7 @@
     "schema:name": "DVC",
     "schema:description": "Manage and version images, audio, video, and text files in storage and organize your ML modeling process into a reproducible workflow.",
     "schema:url": "https://dvc.org/",
-    "schema:applicationCategory": [
-    { "@id": "rs:PrototypeTool", "@type": "@id" },
-    { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id" }
-  ],
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id" },
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD","command-line"],

--- a/data/software-tools/fair_python_cookiecutter.json
+++ b/data/software-tools/fair_python_cookiecutter.json
@@ -7,7 +7,7 @@
   "@type": "schema:SoftwareApplication",
   "schema:name": "Fair Python Cookiecutter",
   "schema:description": "Fair Python Cookiecutter is an opinionated cookiecutter template to kickstart a modern best-practice Python project with FAIR metadata.",
-  "schema:applicationCategory": { "id": "rs:PrototypeTool", "type": "@id"},
+  "schema:applicationCategory": { "@id": "rs:PrototypeTool", "@type": "@id"},
   "schema:url": "https://github.com/Materials-Data-Science-and-Informatics/fair-python-cookiecutter",
   "schema:isAccessibleForFree": true,
   "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},

--- a/data/software-tools/fair_python_cookiecutter.json
+++ b/data/software-tools/fair_python_cookiecutter.json
@@ -13,5 +13,5 @@
   "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
   "rs:howToUse": ["CI/CD","command-line","online-service"],
   "rs:appliesToProgrammingLanguage": ["Python"],
-  "schema:license": { "@id": "https://spdx.org/licenses/MIT.html", "@type": "@id"} 
+  "schema:license": { "@id": "https://spdx.org/licenses/MIT", "@type": "@id"} 
 }

--- a/data/software-tools/fair_python_cookiecutter.json
+++ b/data/software-tools/fair_python_cookiecutter.json
@@ -12,5 +12,6 @@
   "schema:isAccessibleForFree": true,
   "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
   "rs:howToUse": ["CI/CD","command-line","online-service"],
+  "rs:appliesToProgrammingLanguage": ["Python"],
   "schema:license": { "@id": "https://spdx.org/licenses/MIT.html", "@type": "@id"} 
 }

--- a/data/software-tools/fuji.json
+++ b/data/software-tools/fuji.json
@@ -10,7 +10,10 @@
     "schema:url": "https://github.com/softwaresaved/fuji/",
     "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
     "schema:isAccessibleForFree": true,
-    "rs:hasQualityDimension": ["Sustainability"],
+    "rs:hasQualityDimension": {
+      "@id": "rs:Sustainability",
+      "@type": "@id"
+    },    
     "rs:howToUse": ["CI/CD","command-line"],
     "schema:license": ["https://spdx.org/licenses/0BSD.html"]
       

--- a/data/software-tools/fuji.json
+++ b/data/software-tools/fuji.json
@@ -8,7 +8,7 @@
     "schema:name": "F-UJI",
     "schema:description": "Original version for automated assessment of data FAIRness; extended version (POC only - not all metrics are implemented) for research software based on the FAIR4RS principles.",
     "schema:url": "https://github.com/softwaresaved/fuji/",
-    "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
       "@id": "rs:Sustainability",

--- a/data/software-tools/fuji.json
+++ b/data/software-tools/fuji.json
@@ -8,7 +8,7 @@
     "schema:name": "F-UJI",
     "schema:description": "Original version for automated assessment of data FAIRness; extended version (POC only - not all metrics are implemented) for research software based on the FAIR4RS principles.",
     "schema:url": "https://github.com/softwaresaved/fuji/",
-    "schema:applicationCategory": ["ResearchInfrastructureSoftware"],
+    "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": ["Sustainability"],
     "rs:howToUse": ["CI/CD","command-line"],

--- a/data/software-tools/fuji.json
+++ b/data/software-tools/fuji.json
@@ -15,6 +15,5 @@
       "@type": "@id"
     },    
     "rs:howToUse": ["CI/CD","command-line"],
-    "schema:license": ["https://spdx.org/licenses/0BSD.html"]
-      
+    "schema:license": { "@id": "https://spdx.org/licenses/0BSD", "@type": "@id"}       
   }

--- a/data/software-tools/git.json
+++ b/data/software-tools/git.json
@@ -1,0 +1,16 @@
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "rs": "https://w3id.org/everse/rs#"
+  },
+  "@id": "https://w3id.org/everse/tools/git",
+  "@type": "schema:SoftwareApplication",
+  "schema:name": "Git",
+  "schema:description": "Distributed version control system for tracking changes in source code.",
+  "schema:url": "https://git-scm.com/",
+  "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id" },
+  "schema:isAccessibleForFree": true,
+  "rs:hasQualityDimension": { "@id": "rs:Maintainability", "@type": "@id" },
+  "rs:howToUse": ["command-line", "online-service"],
+  "schema:license": { "@id": "https://spdx.org/licenses/GPL-2.0-only", "@type": "@id" }
+}

--- a/data/software-tools/github.json
+++ b/data/software-tools/github.json
@@ -14,6 +14,7 @@
       "@id": "rs:FAIRness",
       "@type": "@id"
     },
-    "rs:howToUse": ["online-service", "CI/CD", "command-line"]
+    "rs:howToUse": ["online-service", "CI/CD", "command-line"], 
+    "schema:license": { "@id": "MIT", "@type": "@id"}
   }
   

--- a/data/software-tools/github.json
+++ b/data/software-tools/github.json
@@ -7,7 +7,7 @@
     "@type": "schema:SoftwareApplication",
     "schema:name": "GitHub",
     "schema:description": "A platform for version control and collaboration, allowing developers to manage and store their code repositories, track changes, and collaborate with others.",
-    "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:url": "https://github.com/",
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {

--- a/data/software-tools/github.json
+++ b/data/software-tools/github.json
@@ -15,6 +15,7 @@
       "@type": "@id"
     },
     "rs:howToUse": ["online-service", "CI/CD", "command-line"], 
+    "rs:usedBy": ["ENVRI-FAIR", "ESCAPE", "EOSC-Life", "PaNOSC", "SSHOC"],
     "schema:license": { "@id": "MIT", "@type": "@id"}
   }
   

--- a/data/software-tools/github.json
+++ b/data/software-tools/github.json
@@ -15,7 +15,7 @@
       "@type": "@id"
     },
     "rs:howToUse": ["online-service", "CI/CD", "command-line"], 
-    "rs:usedBy": ["ENVRI-FAIR", "ESCAPE", "EOSC-Life", "PaNOSC", "SSHOC"],
+    "rs:usedBy": ["ENVRI", "ESCAPE", "EOSC-Life", "PaNOSC", "SSHOC"],
     "schema:license": { "@id": "MIT", "@type": "@id"}
   }
   

--- a/data/software-tools/github.json
+++ b/data/software-tools/github.json
@@ -16,6 +16,6 @@
     },
     "rs:howToUse": ["online-service", "CI/CD", "command-line"], 
     "rs:usedBy": ["ENVRI", "ESCAPE", "EOSC-Life", "PaNOSC", "SSHOC"],
-    "schema:license": { "@id": "MIT", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/MIT", "@type": "@id"}
   }
   

--- a/data/software-tools/github_pages.json
+++ b/data/software-tools/github_pages.json
@@ -8,7 +8,7 @@
     "schema:name": "GitHub Pages",
     "schema:description": "A static site hosting service by GitHub that allows users to publish websites directly from a GitHub repository.",
     "schema:url": "https://pages.github.com/",
-    "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
       "@id": "rs:Sustainability",

--- a/data/software-tools/github_pages.json
+++ b/data/software-tools/github_pages.json
@@ -14,6 +14,7 @@
       "@id": "rs:Documentation",
       "@type": "@id"
     },
-    "rs:howToUse": ["CI/CD", "command-line", "online-service"]
+    "rs:howToUse": ["CI/CD", "command-line", "online-service"],
+    "schema:license": { "@id": "MIT", "@type": "@id"}
   }
   

--- a/data/software-tools/github_pages.json
+++ b/data/software-tools/github_pages.json
@@ -11,7 +11,7 @@
     "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
-      "@id": "rs:Documentation",
+      "@id": "rs:Sustainability",
       "@type": "@id"
     },
     "rs:howToUse": ["CI/CD", "command-line", "online-service"],

--- a/data/software-tools/github_pages.json
+++ b/data/software-tools/github_pages.json
@@ -15,6 +15,6 @@
       "@type": "@id"
     },
     "rs:howToUse": ["CI/CD", "command-line", "online-service"],
-    "schema:license": { "@id": "MIT", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/MIT", "@type": "@id"}
   }
   

--- a/data/software-tools/gitlab.json
+++ b/data/software-tools/gitlab.json
@@ -14,5 +14,5 @@
       "@id": "rs:FAIRness",
       "@type": "@id"
     },
-    "schema:license": { "@id": "MIT", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/MIT", "@type": "@id"}
 }

--- a/data/software-tools/gitlab.json
+++ b/data/software-tools/gitlab.json
@@ -8,18 +8,9 @@
     "schema:name": "GitLab",
     "schema:description": "A platform for version control and collaboration, allowing developers to manage and store their code repositories, track changes, and collaborate with others.",
     "schema:url": "https://gitlab.com/",
-<<<<<<< issue-41
     "schema:isAccessibleForFree": false,
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:hasQualityDimension": {
       "@id": "rs:FAIRness",
       "@type": "@id"
-    },
-=======
-    "schema:isAccessibleForFree": true,
-    "rs:hasQualityDimension": [
-      "FAIRness"
-    ],
->>>>>>> intermidiate_branch_with_reviewed_tools
-    "rs:howToUse": ["CI/CD", "command-line", "online-service"]
-  }
+    }}

--- a/data/software-tools/gitlab.json
+++ b/data/software-tools/gitlab.json
@@ -8,7 +8,8 @@
     "schema:name": "GitLab",
     "schema:description": "A platform for version control and collaboration, allowing developers to manage and store their code repositories, track changes, and collaborate with others.",
     "schema:url": "https://gitlab.com/",
-    "schema:isAccessibleForFree": "paid",
+    "schema:isAccessibleForFree": false,
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:hasQualityDimension": {
       "@id": "rs:FAIRness",
       "@type": "@id"

--- a/data/software-tools/gitlab.json
+++ b/data/software-tools/gitlab.json
@@ -13,4 +13,6 @@
     "rs:hasQualityDimension": {
       "@id": "rs:FAIRness",
       "@type": "@id"
-    }}
+    },
+    "schema:license": { "@id": "MIT", "@type": "@id"}
+}

--- a/data/software-tools/gitlab_cicd.json
+++ b/data/software-tools/gitlab_cicd.json
@@ -15,5 +15,5 @@
     "@type": "@id"
   },
   "rs:howToUse": ["CI/CD", "command-line", "online-service"],
-  "schema:license": { "@id": "MIT", "@type": "@id"}
+  "schema:license": { "@id": "https://spdx.org/licenses/MIT", "@type": "@id"}
 }

--- a/data/software-tools/gitlab_cicd.json
+++ b/data/software-tools/gitlab_cicd.json
@@ -7,7 +7,7 @@
   "@type": "schema:SoftwareApplication",
   "schema:name": "GitLab CICD",
   "schema:description": "A platform for Integration, Delivery and Deployment.",
-  "schema:applicationCategory": { "id": "rs:ResearchInfrastructureSoftware", "type": "@id"},
+  "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
   "schema:url": "https://docs.gitlab.com/ci/",
   "schema:isAccessibleForFree": false,
   "rs:hasQualityDimension": {

--- a/data/software-tools/gitlab_cicd.json
+++ b/data/software-tools/gitlab_cicd.json
@@ -14,5 +14,6 @@
     "@id": "rs:Sustainalibity",
     "@type": "@id"
   },
-  "rs:howToUse": ["CI/CD", "command-line", "online-service"]
+  "rs:howToUse": ["CI/CD", "command-line", "online-service"],
+  "schema:license": { "@id": "MIT", "@type": "@id"}
 }

--- a/data/software-tools/gitlab_pages.json
+++ b/data/software-tools/gitlab_pages.json
@@ -8,12 +8,12 @@
     "schema:name": "GitLab Pages",
     "schema:description": "A feature of GitLab that allows users to publish static websites directly from their Git repositories.",
     "schema:url": "https://about.gitlab.com/stages-devops-lifecycle/pages/",
-    "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
-    "schema:isAccessibleForFree": "free",
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
       "@id": "rs:Documentation",
       "@type": "@id"
     },
-    "rs:howToUse": ["CI/CD", "command-line", "online-service"]
+    "rs:howToUse": ["CI/CD", "online-service"]
   }
   

--- a/data/software-tools/gitlab_pages.json
+++ b/data/software-tools/gitlab_pages.json
@@ -16,5 +16,5 @@
       "@type": "@id"
     },
     "rs:howToUse": ["CI/CD", "online-service"],
-    "schema:license": { "@id": "MIT", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/MIT", "@type": "@id"}
   }

--- a/data/software-tools/gitlab_pages.json
+++ b/data/software-tools/gitlab_pages.json
@@ -10,10 +10,11 @@
     "schema:description": "A feature of GitLab that allows users to publish static websites directly from their Git repositories.",
     "schema:url": "https://about.gitlab.com/stages-devops-lifecycle/pages/",
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-    "schema:isAccessibleForFree": false,
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
       "@id": "rs:Documentation",
       "@type": "@id"
     },
-    "rs:howToUse": ["CI/CD", "online-service"]
+    "rs:howToUse": ["CI/CD", "online-service"],
+    "schema:license": { "@id": "MIT", "@type": "@id"}
   }

--- a/data/software-tools/gitlab_pages.json
+++ b/data/software-tools/gitlab_pages.json
@@ -1,5 +1,5 @@
 {
-<<<<<<< issue-41
+
     "@context": {
       "schema": "http://schema.org/",
       "rs": "https://w3id.org/everse/rs#"
@@ -10,30 +10,10 @@
     "schema:description": "A feature of GitLab that allows users to publish static websites directly from their Git repositories.",
     "schema:url": "https://about.gitlab.com/stages-devops-lifecycle/pages/",
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-    "schema:isAccessibleForFree": true,
+    "schema:isAccessibleForFree": false,
     "rs:hasQualityDimension": {
       "@id": "rs:Documentation",
       "@type": "@id"
     },
     "rs:howToUse": ["CI/CD", "online-service"]
   }
-  
-=======
-  "@context": {
-    "schema": "http://schema.org/",
-    "rs": "https://w3id.org/everse/rs#"
-  },
-  "@id": "https://w3id.org/everse/tools/gitlab_pages",
-  "@type": "schema:SoftwareApplication",
-  "schema:name": "GitLab Pages",
-  "schema:description": "GitLab Pages is a feature of GitLab that allows users to publish static websites directly from their Git repositories.",
-  "schema:url": "https://docs.gitlab.com/user/project/pages/",
-  "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
-  "schema:isAccessibleForFree": false,
-  "rs:hasQualityDimension": {
-    "@id": "rs:Sustainability",
-    "@type": "@id"
-  },
-  "rs:howToUse": ["CI/CD", "command-line", "online-service"]
-}
->>>>>>> intermidiate_branch_with_reviewed_tools

--- a/data/software-tools/gitlab_pages.json
+++ b/data/software-tools/gitlab_pages.json
@@ -12,7 +12,7 @@
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
-      "@id": "rs:Documentation",
+      "@id": "rs:Sustainability",
       "@type": "@id"
     },
     "rs:howToUse": ["CI/CD", "online-service"],

--- a/data/software-tools/hermes_workflow.json
+++ b/data/software-tools/hermes_workflow.json
@@ -7,10 +7,10 @@
     "@type": "schema:SoftwareApplication",
     "schema:name": "Hermes Workflows",
     "schema:description": "The HERMES workflow enables automated publication of rich research software metadata and artifacts to publication repositories using open source tooling.",
-    "schema:url": "https://www.oracle.com/java/technologies/javase/javadoc-tool.html",
+    "schema:url": "https://hermes.software-metadata.pub/en/latest/",
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-    "rs:howToUse": ["command-line"],
+    "rs:howToUse": ["command-line", "CI/CD"],
     "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id"}
   }

--- a/data/software-tools/hermes_workflow.json
+++ b/data/software-tools/hermes_workflow.json
@@ -12,5 +12,5 @@
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:howToUse": ["command-line", "CI/CD"],
-    "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0", "@type": "@id"}
   }

--- a/data/software-tools/hermes_workflow.json
+++ b/data/software-tools/hermes_workflow.json
@@ -8,9 +8,9 @@
     "schema:name": "Hermes Workflows",
     "schema:description": "The HERMES workflow enables automated publication of rich research software metadata and artifacts to publication repositories using open source tooling.",
     "schema:url": "https://www.oracle.com/java/technologies/javase/javadoc-tool.html",
-    "schema:isAccessibleForFree": "free",
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
-    "rs:howToUse": ["online-service"],
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
+    "rs:howToUse": ["command-line"],
     "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id"}
-      
   }

--- a/data/software-tools/howfairis.json
+++ b/data/software-tools/howfairis.json
@@ -8,10 +8,10 @@
     "schema:name": "howfairis",
     "schema:description": "Command line tool to analyze a GitHub or GitLab repository's compliance with the fair-software.eu recommendations",
     "schema:url": "https://github.com/fair-software/howfairis",
-    "schema:applicationCategory": {"@id": "rs:AnalysisCode", "@type": "@id"},
-    "schema:isAccessibleForFree": "free",
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:FAIRness", "@type": "@id"},
-    "rs:howToUse": ["CI/CD","command-line"],
+    "rs:howToUse": ["command-line"],
     "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id"}
       
   }

--- a/data/software-tools/howfairis.json
+++ b/data/software-tools/howfairis.json
@@ -8,11 +8,7 @@
     "schema:name": "howfairis",
     "schema:description": "Command line tool to analyze a GitHub or GitLab repository's compliance with the fair-software.eu recommendations",
     "schema:url": "https://github.com/fair-software/howfairis",
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-=======
-    "schema:applicationCategory": {"@id": "rs:AnalysisCode", "@type": "@id"},
->>>>>>> intermidiate_branch_with_reviewed_tools
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:FAIRness", "@type": "@id"},
     "rs:howToUse": ["command-line"],

--- a/data/software-tools/howfairis.json
+++ b/data/software-tools/howfairis.json
@@ -12,6 +12,6 @@
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:FAIRness", "@type": "@id"},
     "rs:howToUse": ["command-line"],
-    "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0.html", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/Apache-2.0", "@type": "@id"}
       
   }

--- a/data/software-tools/hugo.json
+++ b/data/software-tools/hugo.json
@@ -11,7 +11,7 @@
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
-      "@id": "rs:Documentation",
+      "@id": "rs:Sustainability",
       "@type": "@id"
     },
     "rs:howToUse": ["CI/CD", "command-line"],

--- a/data/software-tools/hugo.json
+++ b/data/software-tools/hugo.json
@@ -8,13 +8,13 @@
     "schema:name": "Hugo",
     "schema:description": "A fast and flexible static site generator written in Go, known for its speed and flexibility in creating websites.",
     "schema:url": "https://gohugo.io/",
-    "schema:applicationCategory": {"@id": "rs:AnalysisCode", "@type": "@id"},
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:isAccessibleForFree": "free",
     "rs:hasQualityDimension": {
       "@id": "rs:Documentation",
       "@type": "@id"
     },
-    "rs:howToUse": ["CI/CD", "command-line", "online-service"],
+    "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": {
       "@id": "https://opensource.org/licenses/Apache-2.0",
       "@type": "@id"

--- a/data/software-tools/hugo.json
+++ b/data/software-tools/hugo.json
@@ -8,13 +8,8 @@
     "schema:name": "Hugo",
     "schema:description": "A fast and flexible static site generator written in Go, known for its speed and flexibility in creating websites.",
     "schema:url": "https://gohugo.io/",
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-    "schema:isAccessibleForFree": "free",
-=======
-    "schema:applicationCategory": {"@id": "rs:AnalysisCode", "@type": "@id"},
     "schema:isAccessibleForFree": true,
->>>>>>> intermidiate_branch_with_reviewed_tools
     "rs:hasQualityDimension": {
       "@id": "rs:Documentation",
       "@type": "@id"

--- a/data/software-tools/javadoc.json
+++ b/data/software-tools/javadoc.json
@@ -8,10 +8,10 @@
     "schema:name": "javadoc",
     "schema:description": "Documentation generator for Java used to generate API documentation in HTML format from Java source code",
     "schema:url": "https://www.oracle.com/java/technologies/javase/javadoc-tool.html",
-    "schema:applicationCategory": {"@id": "rs:AnalysisCode", "@type": "@id"},
-    "schema:isAccessibleForFree": "free",
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
-    "rs:howToUse": ["CI/CD", "command-line", "online-service"],
+    "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": { "@id": "", "@type": "@id"}
       
   }

--- a/data/software-tools/javadoc.json
+++ b/data/software-tools/javadoc.json
@@ -12,6 +12,7 @@
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
+    "rs:appliesToProgrammingLanguage": ["Java"],
     "schema:license": { "@id": "", "@type": "@id"}
       
   }

--- a/data/software-tools/javadoc.json
+++ b/data/software-tools/javadoc.json
@@ -13,6 +13,6 @@
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
     "rs:appliesToProgrammingLanguage": ["Java"],
-    "schema:license": { "@id": "", "@type": "@id"}
+    "schema:license": { "@id": "https://www.oracle.com/downloads/licenses/no-fee-license", "@type": "@id"}
       
   }

--- a/data/software-tools/javadoc.json
+++ b/data/software-tools/javadoc.json
@@ -8,18 +8,10 @@
     "schema:name": "javadoc",
     "schema:description": "Documentation generator for Java used to generate API documentation in HTML format from Java source code",
     "schema:url": "https://www.oracle.com/java/technologies/javase/javadoc-tool.html",
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": { "@id": "", "@type": "@id"}
-=======
-    "schema:applicationCategory": ["AnalysisCode"],
-    "schema:isAccessibleForFree": true,
-    "rs:hasQualityDimension": ["Maintainability"],
-    "rs:howToUse": ["CI/CD", "command-line", "online-service"],
-    "schema:license": ["MIT"]
->>>>>>> intermidiate_branch_with_reviewed_tools
       
   }

--- a/data/software-tools/javadoc.json
+++ b/data/software-tools/javadoc.json
@@ -10,7 +10,7 @@
     "schema:url": "https://www.oracle.com/java/technologies/javase/javadoc-tool.html",
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:isAccessibleForFree": true,
-    "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
+    "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": { "@id": "", "@type": "@id"}
       

--- a/data/software-tools/pelican.json
+++ b/data/software-tools/pelican.json
@@ -11,7 +11,7 @@
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
-      "@id": "rs:Documentation",
+      "@id": "rs:Sustainability",
       "@type": "@id"
     },
     "rs:howToUse": ["CI/CD", "command-line"],

--- a/data/software-tools/pelican.json
+++ b/data/software-tools/pelican.json
@@ -8,13 +8,13 @@
     "schema:name": "Pelican",
     "schema:description": "A static site generator written in Python, designed for building content-focused websites.",
     "schema:url": "https://blog.getpelican.com/",
-    "schema:applicationCategory": {"@id": "rs:AnalysisCode", "@type": "@id"},
-    "schema:isAccessibleForFree": "free",
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
       "@id": "rs:Documentation",
       "@type": "@id"
     },
-    "rs:howToUse": ["CI/CD", "command-line", "online-service"],
+    "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": {
       "@id": "https://www.gnu.org/licenses/agpl-3.0.html",
       "@type": "@id"

--- a/data/software-tools/pelican.json
+++ b/data/software-tools/pelican.json
@@ -8,11 +8,7 @@
     "schema:name": "Pelican",
     "schema:description": "A static site generator written in Python, designed for building content-focused websites.",
     "schema:url": "https://blog.getpelican.com/",
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-=======
-    "schema:applicationCategory": {"@id": "rs:AnalysisCode", "@type": "@id"},
->>>>>>> intermidiate_branch_with_reviewed_tools
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {
       "@id": "rs:Documentation",

--- a/data/software-tools/pelican.json
+++ b/data/software-tools/pelican.json
@@ -16,7 +16,7 @@
     },
     "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": {
-      "@id": "https://www.gnu.org/licenses/agpl-3.0.html",
+      "@id": "https://www.gnu.org/licenses/agpl-3.0",
       "@type": "@id"
     }
   }

--- a/data/software-tools/playwright.json
+++ b/data/software-tools/playwright.json
@@ -8,9 +8,10 @@
     "schema:name": "Playwright",
     "schema:description": "Framework for Web testing and automation, allowing testing using Chromium, Firefox and WebKit with a single API",
     "schema:url": "https://playwright.dev/docs/intro",
-    "schema:isAccessibleForFree": "free",
+    "schema:isAccessibleForFree": true,
+    "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
-    "rs:howToUse": ["online-service"],
+    "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": { "@id": "https://opensource.org/licenses/Apache-2.0", "@type": "@id"}
       
   }

--- a/data/software-tools/playwright.json
+++ b/data/software-tools/playwright.json
@@ -7,12 +7,9 @@
     "@type": "schema:SoftwareApplication",
     "schema:name": "Playwright",
     "schema:description": "Framework for Web testing and automation, allowing testing using Chromium, Firefox and WebKit with a single API",
-    "schema:url": "https://playwright.dev/docs/intro",
+    "schema:url": "https://playwright.dev/",
     "schema:isAccessibleForFree": true,
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
-=======
->>>>>>> intermidiate_branch_with_reviewed_tools
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": { "@id": "https://opensource.org/licenses/Apache-2.0", "@type": "@id"}

--- a/data/software-tools/scorep.json
+++ b/data/software-tools/scorep.json
@@ -8,10 +8,10 @@
     "schema:name": "Score-P",
     "schema:description": "The Score-P (Scalable Performance Measurement Infrastructure for Parallel Codes) measurement infrastructure is a highly scalable and easy-to-use tool suite for profiling and event trace recording of HPC applications.",
     "schema:url": "https://gitlab.com/score-p/scorep",
-    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-    "schema:isAccessibleForFree": "free",
+    "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
-    "rs:howToUse": ["CI/CD","online-service"],
+    "rs:howToUse": ["CI/CD", "command-line"],
     "schema:license": { "@id": "https://spdx.org/licenses/0BSD.html", "@type": "@id"}
       
   }

--- a/data/software-tools/scorep.json
+++ b/data/software-tools/scorep.json
@@ -8,11 +8,7 @@
     "schema:name": "Score-P",
     "schema:description": "The Score-P (Scalable Performance Measurement Infrastructure for Parallel Codes) measurement infrastructure is a highly scalable and easy-to-use tool suite for profiling and event trace recording of HPC applications.",
     "schema:url": "https://gitlab.com/score-p/scorep",
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
-=======
-    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
->>>>>>> intermidiate_branch_with_reviewed_tools
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],

--- a/data/software-tools/scorep.json
+++ b/data/software-tools/scorep.json
@@ -13,6 +13,6 @@
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
     "rs:appliesToProgrammingLanguage": ["C", "C++"],
-    "schema:license": { "@id": "https://spdx.org/licenses/0BSD.html", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/0BSD", "@type": "@id"}
       
   }

--- a/data/software-tools/scorep.json
+++ b/data/software-tools/scorep.json
@@ -12,6 +12,7 @@
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line"],
+    "rs:appliesToProgrammingLanguage": ["C", "C++"],
     "schema:license": { "@id": "https://spdx.org/licenses/0BSD.html", "@type": "@id"}
       
   }

--- a/data/software-tools/software_heritage.json
+++ b/data/software-tools/software_heritage.json
@@ -8,7 +8,8 @@
     "schema:name": "Software Heritage",
     "schema:description": "Collects, preserves, curates and makes available software in source code form as cultural heritage",
     "schema:url": "https://www.softwareheritage.org",
-    "schema:isAccessibleForFree": "free",
+    "schema:isAccessibleForFree": true,
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
-    "rs:howToUse": ["CI/CD","command-line"]
+    "rs:howToUse": ["online-service","command-line"]
   }

--- a/data/software-tools/software_heritage.json
+++ b/data/software-tools/software_heritage.json
@@ -12,5 +12,5 @@
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["online-service","command-line"],
-    "schema:license": { "@id": "AGPL v3", "@type": "@id"}
+    "schema:license": { "@id": "https://www.gnu.org/licenses/agpl-3.0", "@type": "@id"}
   }

--- a/data/software-tools/software_heritage.json
+++ b/data/software-tools/software_heritage.json
@@ -9,10 +9,7 @@
     "schema:description": "Collects, preserves, curates and makes available software in source code form as cultural heritage",
     "schema:url": "https://www.softwareheritage.org",
     "schema:isAccessibleForFree": true,
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-=======
->>>>>>> intermidiate_branch_with_reviewed_tools
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["online-service","command-line"]
   }

--- a/data/software-tools/software_heritage.json
+++ b/data/software-tools/software_heritage.json
@@ -11,5 +11,6 @@
     "schema:isAccessibleForFree": true,
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
-    "rs:howToUse": ["online-service","command-line"]
+    "rs:howToUse": ["online-service","command-line"],
+    "schema:license": { "@id": "AGPL v3", "@type": "@id"}
   }

--- a/data/software-tools/somef.json
+++ b/data/software-tools/somef.json
@@ -9,8 +9,8 @@
     "schema:description": "Software Metadata Extraction Framework (SOMEF) is a command line interface for automatically extracting relevant information from README files",
     "schema:url": "https://github.com/KnowledgeCaptureAndDiscovery/somef",
     "schema:isAccessibleForFree": true,
-    "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
-    "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
+    "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:howToUse": ["command-line", "CI/CD"],
     "schema:license": { "@id": "https://spdx.org/licenses/MIT.html", "@type": "@id"}
       

--- a/data/software-tools/somef.json
+++ b/data/software-tools/somef.json
@@ -8,9 +8,10 @@
     "schema:name": "SOMEF",
     "schema:description": "Software Metadata Extraction Framework (SOMEF) is a command line interface for automatically extracting relevant information from README files",
     "schema:url": "https://github.com/KnowledgeCaptureAndDiscovery/somef",
-    "schema:isAccessibleForFree": "free",
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
-    "rs:howToUse": ["CI/CD","online-service"],
+    "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
+    "rs:howToUse": ["command-line", "CI/CD"],
     "schema:license": { "@id": "https://spdx.org/licenses/MIT.html", "@type": "@id"}
       
   }

--- a/data/software-tools/somef.json
+++ b/data/software-tools/somef.json
@@ -12,6 +12,6 @@
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:howToUse": ["command-line", "CI/CD"],
-    "schema:license": { "@id": "https://spdx.org/licenses/MIT.html", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/MIT", "@type": "@id"}
       
   }

--- a/data/software-tools/somesy.json
+++ b/data/software-tools/somesy.json
@@ -12,6 +12,6 @@
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:howToUse": ["CI/CD","command-line"],
-    "schema:license": { "@id": "https://spdx.org/licenses/MIT.html", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/MIT", "@type": "@id"}
       
   }

--- a/data/software-tools/somesy.json
+++ b/data/software-tools/somesy.json
@@ -8,9 +8,10 @@
     "schema:name": "Somesy",
     "schema:description": "Somesy (software metadata sync) is a CLI tool to avoid messy software project metadata by keeping it in sync.",
     "schema:url": "https://github.com/Materials-Data-Science-and-Informatics/somesy",
-    "schema:isAccessibleForFree": "free",
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
-    "rs:howToUse": ["CI/CD","online-service"],
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
+    "rs:howToUse": ["CI/CD","command-line"],
     "schema:license": { "@id": "https://spdx.org/licenses/MIT.html", "@type": "@id"}
       
   }

--- a/data/software-tools/sphinx.json
+++ b/data/software-tools/sphinx.json
@@ -13,6 +13,6 @@
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["command-line", "CI/CD"],
     "rs:appliesToProgrammingLanguage": ["Python"],
-    "schema:license": { "@id": "https://spdx.org/licenses/BSD-2-Clause.html", "@type": "@id"}
+    "schema:license": { "@id": "https://spdx.org/licenses/BSD-2-Clause", "@type": "@id"}
       
   }

--- a/data/software-tools/sphinx.json
+++ b/data/software-tools/sphinx.json
@@ -10,7 +10,7 @@
     "schema:url": "https://www.sphinx-doc.org",
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "schema:isAccessibleForFree": true,
-    "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
+    "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["command-line", "CI/CD"],
     "schema:license": { "@id": "https://spdx.org/licenses/BSD-2-Clause.html", "@type": "@id"}
       

--- a/data/software-tools/sphinx.json
+++ b/data/software-tools/sphinx.json
@@ -8,11 +8,7 @@
     "schema:name": "sphinx",
     "schema:description": "Documentation generator from reStructuredText files primarily for Python, but also supports other languages - C++, C, JavaScript.",
     "schema:url": "https://www.sphinx-doc.org",
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-=======
-    "schema:applicationCategory": {"@id":"rs:AnalysisCode", "@type": "@id"}, 
->>>>>>> intermidiate_branch_with_reviewed_tools
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
     "rs:howToUse": ["command-line", "CI/CD"],

--- a/data/software-tools/sphinx.json
+++ b/data/software-tools/sphinx.json
@@ -12,6 +12,7 @@
     "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["command-line", "CI/CD"],
+    "rs:appliesToProgrammingLanguage": ["Python"],
     "schema:license": { "@id": "https://spdx.org/licenses/BSD-2-Clause.html", "@type": "@id"}
       
   }

--- a/data/software-tools/sphinx.json
+++ b/data/software-tools/sphinx.json
@@ -8,10 +8,10 @@
     "schema:name": "sphinx",
     "schema:description": "Documentation generator from reStructuredText files primarily for Python, but also supports other languages - C++, C, JavaScript.",
     "schema:url": "https://www.sphinx-doc.org",
-    "schema:applicationCategory": {"@id":"rs:AnalysisCode", "@type": "@id"}, 
-    "schema:isAccessibleForFree": "free",
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
+    "schema:isAccessibleForFree": true,
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
-    "rs:howToUse": ["online-service"],
+    "rs:howToUse": ["command-line", "CI/CD"],
     "schema:license": { "@id": "https://spdx.org/licenses/BSD-2-Clause.html", "@type": "@id"}
       
   }

--- a/data/software-tools/sqaaas.json
+++ b/data/software-tools/sqaaas.json
@@ -12,6 +12,6 @@
     "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["online-service", "CI/CD"],
-    "schema:license": { "@id": "https://www.gnu.org/licenses/gpl-3.0.en.html", "@type": "@id"}
+    "schema:license": { "@id": "https://www.gnu.org/licenses/gpl-3.0.en", "@type": "@id"}
       
   }

--- a/data/software-tools/sqaaas.json
+++ b/data/software-tools/sqaaas.json
@@ -9,10 +9,7 @@
     "schema:description": "Software Quality Assessment as a Service - the Quality Assessment & Awarding building block analysing the level of completeness with the FAIR4RS reference criteria for any given release of your software",
     "schema:url": "https://sqaaas.eosc-synergy.eu/",
     "schema:isAccessibleForFree": true,
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
-=======
->>>>>>> intermidiate_branch_with_reviewed_tools
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["online-service", "CI/CD"],
     "schema:license": { "@id": "https://www.gnu.org/licenses/gpl-3.0.en.html", "@type": "@id"}

--- a/data/software-tools/sqaaas.json
+++ b/data/software-tools/sqaaas.json
@@ -8,9 +8,10 @@
     "schema:name": "SQAaas",
     "schema:description": "Software Quality Assessment as a Service - the Quality Assessment & Awarding building block analysing the level of completeness with the FAIR4RS reference criteria for any given release of your software",
     "schema:url": "https://sqaaas.eosc-synergy.eu/",
-    "schema:isAccessibleForFree": "free",
+    "schema:isAccessibleForFree": true,
+    "schema:applicationCategory": { "@id": "rs:AnalysisCode", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
-    "rs:howToUse": ["online-service"],
+    "rs:howToUse": ["online-service", "CI/CD"],
     "schema:license": { "@id": "https://www.gnu.org/licenses/gpl-3.0.en.html", "@type": "@id"}
       
   }

--- a/data/software-tools/zenodo.json
+++ b/data/software-tools/zenodo.json
@@ -11,5 +11,6 @@
     "schema:isAccessibleForFree": true,
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
-    "rs:howToUse": ["CI/CD", "command-line", "online-service"]
+    "rs:howToUse": ["CI/CD", "command-line", "online-service"],
+    "schema:license": {"@id": " https://ohwr.org/cernohl/", "@type": "@id"}
   }

--- a/data/software-tools/zenodo.json
+++ b/data/software-tools/zenodo.json
@@ -12,5 +12,6 @@
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line", "online-service"],
+    "rs:usedBy": ["ENVRI-FAIR", "ESCAPE", "EOSC-Life", "PaNOSC", "SSHOC"],
     "schema:license": {"@id": " https://ohwr.org/cernohl/", "@type": "@id"}
   }

--- a/data/software-tools/zenodo.json
+++ b/data/software-tools/zenodo.json
@@ -12,6 +12,6 @@
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line", "online-service"],
-    "rs:usedBy": ["ENVRI-FAIR", "ESCAPE", "EOSC-Life", "PaNOSC", "SSHOC"],
+    "rs:usedBy": ["ENVRI", "ESCAPE", "EOSC-Life", "PaNOSC", "SSHOC"],
     "schema:license": {"@id": " https://ohwr.org/cernohl/", "@type": "@id"}
   }

--- a/data/software-tools/zenodo.json
+++ b/data/software-tools/zenodo.json
@@ -10,7 +10,7 @@
     "schema:url": "https://zenodo.org/",
     "schema:isAccessibleForFree": true,
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-    "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
+    "rs:hasQualityDimension": {"@id":"rs:Sustainability", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line", "online-service"],
     "schema:license": {"@id": " https://ohwr.org/cernohl/", "@type": "@id"}
   }

--- a/data/software-tools/zenodo.json
+++ b/data/software-tools/zenodo.json
@@ -8,7 +8,8 @@
     "schema:name": "zenodo",
     "schema:description": "Open repository for EU-funded research outputs from Horizon Europe, Euratom, and earlier Framework Programmes.",
     "schema:url": "https://zenodo.org/",
-    "schema:isAccessibleForFree": "free",
+    "schema:isAccessibleForFree": true,
+    "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
-    "rs:howToUse": ["CI/CD", "command-line"]
+    "rs:howToUse": ["CI/CD", "command-line", "online-service"]
   }

--- a/data/software-tools/zenodo.json
+++ b/data/software-tools/zenodo.json
@@ -9,10 +9,7 @@
     "schema:description": "Open repository for EU-funded research outputs from Horizon Europe, Euratom, and earlier Framework Programmes.",
     "schema:url": "https://zenodo.org/",
     "schema:isAccessibleForFree": true,
-<<<<<<< issue-41
     "schema:applicationCategory": { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id"},
-=======
->>>>>>> intermidiate_branch_with_reviewed_tools
     "rs:hasQualityDimension": {"@id":"rs:Documentation", "@type": "@id"},
     "rs:howToUse": ["CI/CD", "command-line", "online-service"]
   }

--- a/tests/tools_validation_schema.json
+++ b/tests/tools_validation_schema.json
@@ -116,7 +116,7 @@
       "type": ["string", "array"],
       "items": {
         "type": "string",
-        "enum": ["ENVRI", "ESCAPE", "LS-RI", "PaNOSC", "SSHOC"]
+        "enum": ["ENVRI", "ESCAPE", "LS-RI", "PaNOSC", "SSHOC", "EOSC-Life"]
       }
     },
     "rs:appliesToProgrammingLanguage": {

--- a/tests/tools_validation_schema.json
+++ b/tests/tools_validation_schema.json
@@ -134,7 +134,7 @@
     "schema:license",
     "schema:url",
     "schema:applicationCategory",
-    "schema:hasQualityDimension"
+    "rs:hasQualityDimension"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
For below tools missing metadata is added and schema is reviewed

 
- [x] gitlab_pages.json
- [x] hermes_workflow.json
- [x] howfairis.json
- [x] hugo.json
- [x] javadoc.json
- [x] pelican.json
- [x] playwright.json
- [x] scorep.json
- [x] software_heritage.json
- [x] somef.json
- [x] somesy.json
- [x] bandit.json
- [x] sphinx.json
- [x] sqaaas.json
- [x] zenodo.json