### PR TITLE
Added other social contacts for EVERSE

### DIFF
--- a/config.json
+++ b/config.json
@@ -138,11 +138,15 @@
   },
   "social": [
     {
-      "href": "https://github.com/EVERSE-ResearchSoftware/TechRadar",
-      "icon": "github"
+      "href": "https://bsky.app/profile/eosc-everse.bsky.social",
+      "icon": "x"
     },
     {
-      "href": "https://github.com/orgs/EVERSE-ResearchSoftware/teams/techradar-curators/",
+      "href": "https://www.linkedin.com/company/eosc-everse",
+      "icon": "linkedIn"
+    },
+    {
+      "href": "https://github.com/EVERSE-ResearchSoftware/TechRadar",
       "icon": "github"
     }
   ],


### PR DESCRIPTION
Fixes #98 
Added other social contacts for EVERSE on TechRadar dashboard, Removed curators-team since its getting added in about.md via #96 