### PR TITLE
Remove prefixes from context object

### DIFF
--- a/data/software-tools/apptainer.json
+++ b/data/software-tools/apptainer.json
@@ -1,8 +1,5 @@
 {
-  "@context": {
-    "schema": "http://schema.org/",
-    "rs": "https://w3id.org/everse/rs#"
-  },
+  "@context": "https://w3id.org/everse/rs#",
   "@id": "https://w3id.org/everse/tools/apptainer",
   "@type": "schema:SoftwareApplication",
   "name": "Apptainer",

--- a/data/software-tools/cppunit.json
+++ b/data/software-tools/cppunit.json
@@ -1,8 +1,5 @@
 {
-  "@context": {
-    "schema": "http://schema.org/",
-    "rs": "https://w3id.org/everse/rs#"
-  },
+  "@context": "https://w3id.org/everse/rs#",
   "@id": "https://w3id.org/everse/tools/cppunit",
   "@type": "schema:SoftwareApplication",
   "name": "CppUnit",

--- a/data/software-tools/docker.json
+++ b/data/software-tools/docker.json
@@ -1,8 +1,5 @@
 {
-  "@context": {
-    "schema": "http://schema.org/",
-    "rs": "https://w3id.org/everse/rs#"
-  },
+  "@context": "https://w3id.org/everse/rs#",
   "@id": "https://w3id.org/everse/tools/docker",
   "@type": "schema:SoftwareApplication",
   "name": "Docker",

--- a/data/software-tools/scanoss.json
+++ b/data/software-tools/scanoss.json
@@ -1,4 +1,5 @@
 {
+  "@context": "https://w3id.org/everse/rs#",
   "@id": "https://w3id.org/everse/tools/scanoss",
   "@type": "SoftwareApplication",
   "applicationCategory": {

--- a/data/software-tools/singularityce.json
+++ b/data/software-tools/singularityce.json
@@ -1,8 +1,5 @@
 {
-  "@context": {
-    "schema": "http://schema.org/",
-    "rs": "https://w3id.org/everse/rs#"
-  },
+  "@context": "https://w3id.org/everse/rs#",
   "@id": "https://w3id.org/everse/tools/singularityce",
   "@type": "schema:SoftwareApplication",
   "name": "SingularityCE",

--- a/tests/test_dummy_tools.py
+++ b/tests/test_dummy_tools.py
@@ -7,6 +7,7 @@ schema = load_local_schema("tests/tools_validation_schema.json")
 
 # 1. A tool that should pass validation
 valid_tool = {
+    "@context": "https://w3id.org/everse/rs#",
     "@id": "https://example.com/tool/valid",
     "name": "Valid Tool",
     "description": "This is a valid tool.",
@@ -18,7 +19,17 @@ valid_tool = {
 
 # 2. Tools that should not pass validation
 invalid_tools = [
-    # Missing required property: schema:name
+    # Missing required property: name
+    {
+        "@context": "https://w3id.org/everse/rs#",
+        "@id": "https://example.com/tool/invalid1",
+        "description": "This tool is missing a name.",
+        "url": "https://example.com/tool/invalid1",
+        "license": "https://opensource.org/licenses/MIT",
+        "applicationCategory": {"@id": "rs:AnalysisCode"},
+        "hasQualityDimension": {"@id": "dim:FAIRness"}
+    },
+    # Missing required property: context
     {
         "@id": "https://example.com/tool/invalid1",
         "description": "This tool is missing a name.",
@@ -27,8 +38,9 @@ invalid_tools = [
         "applicationCategory": {"@id": "rs:AnalysisCode"},
         "hasQualityDimension": {"@id": "dim:FAIRness"}
     },
-    # Missing required property: schema:description
+    # Missing required property: description
     {
+        "@context": "https://w3id.org/everse/rs#",
         "@id": "https://example.com/tool/invalid2",
         "name": "Tool without description",
         "url": "https://example.com/tool/invalid2",
@@ -36,8 +48,9 @@ invalid_tools = [
         "applicationCategory": {"@id": "rs:AnalysisCode"},
         "hasQualityDimension": {"@id": "dim:FAIRness"}
     },
-    # Missing required property: schema:license
+    # Missing required property: license
     {
+        "@context": "https://w3id.org/everse/rs#",
         "@id": "https://example.com/tool/invalid3",
         "name": "Tool without license",
         "description": "This tool is missing a license.",
@@ -45,8 +58,9 @@ invalid_tools = [
         "applicationCategory": {"@id": "rs:AnalysisCode"},
         "hasQualityDimension": {"@id": "dim:FAIRness"}
     },
-    # Missing required property: schema:url
+    # Missing required property: url
     {
+        "@context": "https://w3id.org/everse/rs#",
         "@id": "https://example.com/tool/invalid4",
         "name": "Tool without url",
         "description": "This tool is missing a url.",
@@ -56,6 +70,7 @@ invalid_tools = [
     },
     # Invalid applicationCategory
     {
+        "@context": "https://w3id.org/everse/rs#",
         "@id": "https://example.com/tool/invalid5",
         "name": "Invalid Category Tool",
         "description": "This tool has an invalid application category.",
@@ -66,6 +81,7 @@ invalid_tools = [
     },
     # Invalid quality dimension as a string
     {
+        "@context": "https://w3id.org/everse/rs#",
         "@id": "https://example.com/tool/invalid6",
         "name": "Invalid Quality Dimension",
         "description": "This tool has an invalid quality dimension.",
@@ -76,6 +92,7 @@ invalid_tools = [
     },
     # Invalid quality dimension as an object without @id
     {
+        "@context": "https://w3id.org/everse/rs#",
         "@id": "https://example.com/tool/invalid7",
         "name": "Invalid Quality Dimension Object",
         "description": "This tool has an invalid quality dimension object.",

--- a/tests/tools_validation_schema.json
+++ b/tests/tools_validation_schema.json
@@ -46,7 +46,7 @@
   "properties": {
     "@context": {
       "description": "The JSON-LD context for term definitions",
-      "type": [ "string", "object" ]
+      "type": "string"
     },
     "@id": {
       "description": "Unique identifier for the software tool",
@@ -159,6 +159,7 @@
     }
   },
   "required": [
+    "@context",
     "@id",
     "name",
     "description",


### PR DESCRIPTION
Fixes #100 

Latest updated schema doesn't have "schema", "rs" prefixes for "context" object.
Schema metadata entries for few tools e.g. Apptainer, Docker, CPPunit, SingularityCE in main branch is showing those prefixes, this PR fixes the inconsistency for those tools metadata schemas.

Made `context` as a `string` mandatory for validation
Added one more test scenario in case of missing `context` in schema entries

