### PR TITLE
Added REUSE license information and fix footer links

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,3 @@ npm run lint-prettier:fix
 ## Funding
 
 [EVERSE project](https://everse.software/) is funded by the European Commission HORIZON-INFRA-2023-EOSC-01-02 call.
-
-## License
-
-This project is licensed under the Creative Commons License - see the [LICENSE](License) file for details.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -11,7 +11,7 @@ path = [
     "about.md"
 ]
 SPDX-FileCopyrightText = "2025 TechRadar Curators and Organisations, including curators in CITATION.cff, https://everse.software/about/consortium/"
-SPDX-License-Identifier = "Attribution-NonCommercial-ShareAlike 4.0 International"
+SPDX-License-Identifier = "CC-BY-NC-SA-4.0"
 SPDX-Year = "2025"
 SPDX-FileType = "Documentation"
 
@@ -26,7 +26,7 @@ path = [
     "config.json"
 ]
 SPDX-FileCopyrightText = "2025 TechRadar Curators and Organisations, including curators in CITATION.cff, https://everse.software/about/consortium/"
-SPDX-License-Identifier = "Attribution-NonCommercial-ShareAlike 4.0 International"
+SPDX-License-Identifier = "CC-BY-NC-SA-4.0"
 SPDX-Year = "2025"
 SPDX-FileType = "Configuration"
 
@@ -37,4 +37,4 @@ path = [
     ".gitignore"
 ]
 SPDX-FileCopyrightText = "2025 TechRadar Curators and Organisations, including curators in CITATION.cff, https://everse.software/about/consortium/"
-SPDX-License-Identifier = "Attribution-NonCommercial-ShareAlike 4.0 International"
+SPDX-License-Identifier = "CC-BY-NC-SA-4.0"

--- a/config.json
+++ b/config.json
@@ -166,7 +166,7 @@
     "quadrantOverview": "Segments Overview",
     "zoomIn": "Zoom in",
     "filterByTag": "Filter by Tag",
-    "footer": "Technology Radar for tools and services for research software quality developed as part of the EVERSE project, referencing AOE tech radar. Copyright of EVERSE Technology Radar content remains with curators or their organisations. Content is licensed under CC BY 4.0",
+    "footer": "Technology Radar for tools and services for research software quality developed as part of the EVERSE project, referencing AOE tech radar. Copyright of EVERSE Technology Radar content remains with curators or their organisations. Content is licensed under CC BY-NC-SA 4.0",
     "notUpdated": "This item was not updated in last three versions of the Radar. Should it have appeared in one of the more recent editions, there is a good chance it remains pertinent. However, if the item dates back further, its relevance may have diminished and our current evaluation could vary. Regrettably, our capacity to consistently revisit items from past Radar editions is limited.",
     "notFound": "404 - Page not found",
     "pageAbout": "How to use EVERSE Technology Radar",


### PR DESCRIPTION
Fixes #83 

This PR adds 

- licensing information to the repository using the approach suggested by: https://reuse.software/
- Added a REUSE.toml file

LICENSES are kept same as RSQkit  