### PR TITLE
Add has_no_linting_issues indicator to pylint

### DIFF
--- a/data/software-tools/pylint.json
+++ b/data/software-tools/pylint.json
@@ -10,7 +10,10 @@
     "@id": "dim:maintainability",
     "@type": "@id"
   },
-  "measuresQualityIndicator": { "@id": "ind:has_no_linting_issues", "@type": "@id" },
+  "measuresQualityIndicator": {
+    "@id": "ind:has_no_linting_issues",
+    "@type": "@id"
+  },
   "howToUse": ["command-line", "CI/CD"],
   "appliesToProgrammingLanguage": ["Python"],
   "license": "https://opensource.org/licenses/GPL-2.0-only",


### PR DESCRIPTION
This PR serves as an example of how to add indicators to tools description; do not merge at the moment.

Add quality indicator `has_no_linting_issues` to pylint JSON.

Fixes #141

---

## steps for developers to do the same:

### open an issue

- each item in the spreadsheet should be turned into an issue in project https://github.com/orgs/EVERSE-ResearchSoftware/projects/2
  - go to https://github.com/orgs/EVERSE-ResearchSoftware/projects/2
  - create a new issue in backlog
  - assign yourself or someone else
 
### fix the issue
- check that the indicator exists in https://w3id.org/everse/i/indicators/, if not create it in https://github.com/EVERSE-ResearchSoftware/indicators/tree/main/indicators
- update the tool.json (in https://github.com/EVERSE-ResearchSoftware/TechRadar/tree/main/data/software-tools) to add the indicator
- open a PR and mention the issue (`Fixes issue #XXX`)
