### PR TITLE
Added indicator for tool Black

### DIFF
--- a/data/software-tools/black.json
+++ b/data/software-tools/black.json
@@ -16,6 +16,7 @@
     {
       "@id": "https://w3id.org/everse/i/indicators/has_no_linting_issues",
       "@type": "@id"
-    }],
+    }
+  ],
   "howToUse": ["CI/CD", "command-line"]
 }


### PR DESCRIPTION
Added quality indicator `has_no_linting_issues` to black JSON.

Fixes https://github.com/EVERSE-ResearchSoftware/TechRadar/issues/148