### PR TITLE
feat(`generate_techradar_markdowns.py`): added RSQKit line

### DIFF
--- a/scripts/generate_techradar_markdowns.py
+++ b/scripts/generate_techradar_markdowns.py
@@ -35,6 +35,22 @@ def get_items(field):
         items.append(field)
     return items
 
+def rsqkit_to_md(field):
+    """Generates an md written list of the related RSQKit pages"""
+    if not field:
+        return ''
+    links = [f"[{item['title']}]({item['url']})" for item in field]
+
+    print(links)
+
+    if not links:
+        return ''
+    elif len(links) == 1:
+        return links[0]
+    elif len(links) == 2:
+        return ' and '.join(links)
+    else:
+        return ', '.join(links[:-1]) + ' and ' + links[-1]
 
 def generate_markdown(json_ld_file, output_dir, quality_dimension=None, is_multi_dim=False):
     """Generates tools markdown for techradar dashboard from a JSON-LD file."""
@@ -97,6 +113,13 @@ def generate_markdown(json_ld_file, output_dir, quality_dimension=None, is_multi
     if is_multi_dim:
         tags.append('multi-dimensional')
 
+    # Extract RSQKit links
+    rsqkit_field = json_ld.get('rsqkit', [])
+    rsqkit_list_md = rsqkit_to_md(rsqkit_field)
+    rsqkit = ''
+    if rsqkit_list_md:
+        rsqkit = 'See more in RSQKit: ' + rsqkit_list_md
+
     # Prepare markdown content
     markdown_content = f"""---
 title: "{title}"
@@ -111,6 +134,8 @@ Tool License: {license_info}
 Tool url: {url}
 
 Application Category (or Categories in case of multi-tier tool): {', '.join(application_categories)}
+
+{rsqkit}
 """
 
     os.makedirs(output_dir, exist_ok=True)


### PR DESCRIPTION
For #216 to work, we must write the RSQKit links in the `.md` files. However, `.md` files are generated by `scripts/generate_techradar_markdowns.py` – this PR is my suggestion to insert RSQKit links to each `.md` files *without manually changing each .md files* as suggested by the beginning of #220.

While testing, please amend `data/software/pytest.json` with the following:

```json
{
  "@context": "https://w3id.org/everse/rs#",
  "@id": "https://w3id.org/everse/tools/pytest",
  "@type": "schema:SoftwareApplication",
  "name": "pytest",
  "description": "Comprehensive testing framework for Python that enhances research software reliability and maintainability through advanced testing capabilities, fixtures, and plugins, supporting test-driven development practices essential for research software quality assurance.",
  "url": "https://docs.pytest.org/",
  "isAccessibleForFree": true,
  "hasQualityDimension": [
    {
      "@id": "dim:maintainability",
      "@type": "@id"
    },
    {
      "@id": "dim:reliability",
      "@type": "@id"
    }
  ],
  "howToUse": ["command-line", "CI/CD"],
  "appliesToProgrammingLanguage": ["Python"],
  "license": "https://opensource.org/licenses/MIT",
  "applicationCategory": [
    {
      "@id": "rs:AnalysisCode",
      "@type": "@id"
    },
    {
      "@id": "rs:ResearchInfrastructureSoftware",
      "@type": "@id"
    }
  ],
  "rsqkit": [
    {
      "title": "Testing software",
      "url": "https://everse.software/RSQKit/testing_software"
    },
    {
      "title": "Task automation using GitHub Actions",
      "url": "https://everse.software/RSQKit/task_automation_github_actions"
    }
  ]
}
```

I have added an `rsqkit` array of objects, each having `title` and `url` as keys.

Once the python script run, it should add a line `See more in RSQKit: <list-of-rsqkit-pages>` in tools' `.md` pages when having at least one RSQKit related page.

I must also change [`Contributing.md`](https://github.com/EVERSE-ResearchSoftware/TechRadar/blob/dd1aca0baf4c6bfe43e0f9c4c1cadaf17a98ddd4/CONTRIBUTING.md) once the .json labels/keys are validated.