### PR TITLE
Added example RSQKit tasks to Techradar segment pages

### DIFF
--- a/config.json
+++ b/config.json
@@ -26,67 +26,80 @@
       "id": "compatibility",
       "title": "Compatibility",
       "description": "Degree to which a product, system or component can exchange information with other products, systems or components, and/or perform its required functions while sharing the same common environment and resources.",
-      "color": "#4E79A7"
+      "color": "#4E79A7",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
     },
     {
       "id": "fairness",
       "title": "FAIRness",
       "description": "FAIRness refers to the degree to which research software adheres to the FAIR principles: Findable, Accessible, Interoperable, and Reusable.",
-      "color": "#F28E2B"
+      "color": "#F28E2B",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
+
     },
     {
       "id": "flexibility",
       "title": "Flexibility",
       "description": "Degree to which a product can be adapted to changes in its requirements, contexts of use or system environment. ",
-      "color": "#E15759"
+      "color": "#E15759",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
     },
     {
       "id": "functional_suitability",
       "title": "Functional Suitability",
       "description": "This characteristic represents the degree to which a product or system provides functions that meet stated and implied needs when used under specified conditions. ",
-      "color": "#76B7B2"
+      "color": "#76B7B2",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
     },
     {
       "id": "interaction_capability",
       "title": "Interaction Capability",
       "description": "This characteristic represents the degree to which a product or system supports users in performing their tasks and achieving specified goals.",
-      "color": "#59A14F"
+      "color": "#59A14F",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
     },
     {
       "id": "maintainability",
       "title": "Maintainability",
       "description": "This characteristic represents the degree of effectiveness and efficiency with which a product or system can be modified to improve it, correct it or adapt it to changes in environment, and in requirements.",
-      "color": "#EDC948"
+      "color": "#EDC948",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
     },
     {
       "id": "performance_efficiency",
       "title": "Performance Efficiency",
       "description": "This characteristic represents the degree to which a product performs its functions within specified time and throughput parameters and is efficient in the use of resources (such as CPU, memory, storage, network devices, energy, materials...) under specified conditions.",
-      "color": "#B07AA1"
+      "color": "#B07AA1",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
     },
     {
       "id": "reliability",
       "title": "Reliability",
       "description": "Degree to which a system, product or component performs specified functions under specified conditions for a specified period of time.",
-      "color": "#FF9DA7"
+      "color": "#FF9DA7",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
     },
     {
       "id": "safety",
       "title": "Safety",
       "description": "This characteristic represents the degree to which a product under defined conditions to avoid a state in which human life, health, property, or the environment is endangered.",
-      "color": "#9C755F"
+      "color": "#9C755F",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
     },
     {
       "id": "security",
       "title": "Security",
       "description": "Degree to which a product or system defends against attack patterns by malicious actors and protects information and data so that persons or other products or systems have the degree of data access appropriate to their types and levels of authorization.",
-      "color": "#BAB0AC"
+      "color": "#BAB0AC",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
     },
     {
       "id": "sustainability",
       "title": "Sustainability",
       "description": "The capacity of the software to endure. In other words, sustainability means that the software will continue to be available in the future, on new platforms, meeting new needs.",
-      "color": "#5FA2CE"
+      "color": "#5FA2CE",
+      "tasks": [{"title": "Task 1", "link": "https://everse.software/RSQKit/archiving_software#how-to-cite-this-page"}, {"title": "Task 2", "link": "https://everse.software/RSQKit/software_identifiers"}]
+
     }
   ],
   "rings": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "aoe_technology_radar": "github:EVERSE-ResearchSoftware/aoe_technology_radar#v5.1.0",
+        "aoe_technology_radar": "file:../aoe_technology_radar/",
         "npm-package-json-lint": "^9.0.0"
       },
       "devDependencies": {
@@ -18,6 +18,39 @@
       "engines": {
         "node": ">=18",
         "npm": ">=9"
+      }
+    },
+    "../aoe_technology_radar": {
+      "version": "5.0.0-rc.5",
+      "hasInstallScript": true,
+      "bin": {
+        "techradar": "bin/techradar.js"
+      },
+      "devDependencies": {
+        "@commitlint/cli": "^19.8.0",
+        "@commitlint/config-conventional": "^19.8.0",
+        "@trivago/prettier-plugin-sort-imports": "^5.2.2",
+        "@types/node": "^22",
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "clsx": "^2.1.1",
+        "eslint": "^9.25.1",
+        "eslint-config-next": "15.3.1",
+        "fuse.js": "^7.1.0",
+        "gray-matter": "^4.0.3",
+        "highlight.js": "^11.11.1",
+        "husky": "^9.1.7",
+        "lint-staged": "^15.5.1",
+        "marked": "^15.0.11",
+        "marked-highlight": "^2.2.1",
+        "next": "^15.5.2",
+        "postcss-nested": "^7.0.2",
+        "postcss-preset-env": "^10.1.6",
+        "prettier": "^3.5.3",
+        "react": "^19",
+        "react-dom": "^19",
+        "tsx": "^4.19.4",
+        "typescript": "^5"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -35,9 +68,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -131,12 +164,8 @@
       }
     },
     "node_modules/aoe_technology_radar": {
-      "version": "5.0.0-rc.5",
-      "resolved": "git+ssh://git@github.com/EVERSE-ResearchSoftware/aoe_technology_radar.git#9bb4ed2215ce886e55242b6709d0a5975f364b6c",
-      "hasInstallScript": true,
-      "bin": {
-        "techradar": "bin/techradar.js"
-      }
+      "resolved": "../aoe_technology_radar",
+      "link": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -270,9 +299,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -333,9 +362,9 @@
       }
     },
     "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -611,9 +640,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -1120,12 +1149,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -1182,9 +1211,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint-prettier:fix": "prettier --write data/software-tools"
   },
   "dependencies": {
-    "aoe_technology_radar": "github:EVERSE-ResearchSoftware/aoe_technology_radar#v5.1.0",
+    "aoe_technology_radar": "file:../aoe_technology_radar/", 
     "npm-package-json-lint": "^9.0.0"
   },
   "engines": {


### PR DESCRIPTION
Fixes #217 

This PR adds an example RSQkit tasks to TechRadar segments
Relevant updates has been made on Everse AOE techradar fork https://github.com/EVERSE-ResearchSoftware/aoe_technology_radar/pull/4 
 
 After updates Techradar segments look like this
 
 
<img width="1269" height="836" alt="image" src="https://github.com/user-attachments/assets/df930afc-0d95-4569-82ab-58c93309dffe" />

 