### PR TITLE
Add indicators for tox.json

### DIFF
--- a/data/software-tools/tox.json
+++ b/data/software-tools/tox.json
@@ -24,13 +24,8 @@
       "@type": "@id"
     }
   ],
-  "howToUse": [
-    "command-line",
-    "CI/CD"
-  ],
-  "appliesToProgrammingLanguage": [
-    "Python"
-  ],
+  "howToUse": ["command-line", "CI/CD"],
+  "appliesToProgrammingLanguage": ["Python"],
   "license": "https://opensource.org/licenses/MIT",
   "applicationCategory": {
     "@id": "rs:ResearchInfrastructureSoftware",


### PR DESCRIPTION
Resolves #208

Add indicator references for tox.json.

Project: https://github.com/orgs/EVERSE-ResearchSoftware/projects/2