### PR TITLE
Add indicators for sonarqube.json

### DIFF
--- a/data/software-tools/sonarqube.json
+++ b/data/software-tools/sonarqube.json
@@ -8,14 +8,37 @@
   },
   "description": "Continuous code quality platform that automatically detects bugs, vulnerabilities, and code smells across multiple programming languages, providing comprehensive static analysis to improve software maintainability, security, and reliability.",
   "hasQualityDimension": [
-    { "@id": "dim:maintainability", "@type": "@id" },
-    { "@id": "dim:security", "@type": "@id" },
-    { "@id": "dim:reliability", "@type": "@id" }
+    {
+      "@id": "dim:maintainability",
+      "@type": "@id"
+    },
+    {
+      "@id": "dim:security",
+      "@type": "@id"
+    },
+    {
+      "@id": "dim:reliability",
+      "@type": "@id"
+    }
   ],
   "howToUse": ["CI/CD", "online-service"],
   "isAccessibleForFree": true,
   "license": "https://spdx.org/licenses/GPL-3.0-only",
   "name": "SonarQube",
   "appliesToProgrammingLanguage": ["Java", "Python", "JavaScript", "C#", "C++"],
-  "url": "https://www.sonarqube.org/"
+  "url": "https://www.sonarqube.org/",
+  "improvesQualityIndicator": [
+    {
+      "@id": "https://w3id.org/everse/i/indicators/no_critical_vulnerability",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/no_leaked_credentials",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/static_analysis_common_vulnerabilities",
+      "@type": "@id"
+    }
+  ]
 }


### PR DESCRIPTION
Resolves #205

Add indicator references for sonarqube.json.

Project: https://github.com/orgs/EVERSE-ResearchSoftware/projects/2