### PR TITLE
Add indicators for ruff.json

### DIFF
--- a/data/software-tools/ruff.json
+++ b/data/software-tools/ruff.json
@@ -26,5 +26,11 @@
       "@id": "rs:PrototypeTool",
       "@type": "@id"
     }
+  ],
+  "improvesQualityIndicator": [
+    {
+      "@id": "https://w3id.org/everse/i/indicators/has_no_linting_issues",
+      "@type": "@id"
+    }
   ]
 }


### PR DESCRIPTION
Resolves #197

Add indicator references for ruff.json.

Project: https://github.com/orgs/EVERSE-ResearchSoftware/projects/2