### PR TITLE
Add indicators for creative-commons-license-chooser.json

### DIFF
--- a/data/software-tools/creative-commons-license-chooser.json
+++ b/data/software-tools/creative-commons-license-chooser.json
@@ -7,10 +7,19 @@
     "@type": "@id"
   },
   "description": "A web-based tool to help users select an appropriate Creative Commons license for their work.",
-  "hasQualityDimension": { "@id": "dim:fairness", "@type": "@id" },
+  "hasQualityDimension": {
+    "@id": "dim:fairness",
+    "@type": "@id"
+  },
   "howToUse": ["command-line"],
   "isAccessibleForFree": true,
   "license": "https://creativecommons.org/publicdomain/zero/1.0",
   "name": "Creative Commons License Chooser",
-  "url": "https://chooser-beta.creativecommons.org/"
+  "url": "https://chooser-beta.creativecommons.org/",
+  "improvesQualityIndicator": [
+    {
+      "@id": "https://w3id.org/everse/i/indicators/software_has_license",
+      "@type": "@id"
+    }
+  ]
 }


### PR DESCRIPTION
Resolves #155

Add indicator references for creative-commons-license-chooser.json.

Project: https://github.com/orgs/EVERSE-ResearchSoftware/projects/2