### PR TITLE
Add indicators for hadolint.json

### DIFF
--- a/data/software-tools/hadolint.json
+++ b/data/software-tools/hadolint.json
@@ -40,6 +40,6 @@
     {
       "@id": "https://w3id.org/everse/i/indicators/has_no_linting_issues",
       "@type": "@id"
-    },
+    }
   ]
 }


### PR DESCRIPTION
Resolves #179

Add indicator references for hadolint.json.

Project: https://github.com/orgs/EVERSE-ResearchSoftware/projects/2