### PR TITLE
Add indicators for gitlab-cicd.json

### DIFF
--- a/data/software-tools/gitlab-cicd.json
+++ b/data/software-tools/gitlab-cicd.json
@@ -8,12 +8,32 @@
   },
   "description": "Integrated continuous integration and deployment platform that automates research software testing, building, and deployment workflows, improving software reliability and sustainability through comprehensive DevOps practices.",
   "hasQualityDimension": [
-    { "@id": "dim:sustainability", "@type": "@id" },
-    { "@id": "dim:reliability", "@type": "@id" }
+    {
+      "@id": "dim:sustainability",
+      "@type": "@id"
+    },
+    {
+      "@id": "dim:reliability",
+      "@type": "@id"
+    }
   ],
   "howToUse": ["CI/CD", "command-line", "online-service"],
   "isAccessibleForFree": false,
   "license": "https://spdx.org/licenses/MIT",
   "name": "GitLab CICD",
-  "url": "https://docs.gitlab.com/ci/"
+  "url": "https://docs.gitlab.com/ci/",
+  "improvesQualityIndicator": [
+    {
+      "@id": "https://w3id.org/everse/i/indicators/repository_workflows",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/software_has_tests",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/has_ci-tests",
+      "@type": "@id"
+    }
+  ]
 }


### PR DESCRIPTION
Resolves #176

Add indicator references for gitlab-cicd.json.

Project: https://github.com/orgs/EVERSE-ResearchSoftware/projects/2