### PR TITLE
Add indicators for cppunit.json

### DIFF
--- a/data/software-tools/cppunit.json
+++ b/data/software-tools/cppunit.json
@@ -26,7 +26,7 @@
     {
       "@id": "https://w3id.org/everse/i/indicators/software_has_tests",
       "@type": "@id"
-    }   
+    }
   ],
   "howToUse": ["command-line"],
   "appliesToProgrammingLanguage": ["C++"],


### PR DESCRIPTION
Resolves https://github.com/EVERSE-ResearchSoftware/TechRadar/issues/154.

Add indicator references for `cppunit.json`.

Project: https://github.com/orgs/EVERSE-ResearchSoftware/projects/2

---
Hi all!

my name is Stella and I am from CERTH team and just joined EVERSE. 

This is my first PR to contribute to TechRadar and get familiar with the process :) 