### PR TITLE
Add pixi to tech radar software tools

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -50,6 +50,10 @@ authors:
     orcid: 'https://orcid.org/0009-0008-9084-064X' 
   - family-names: Garijo
     given-names: Daniel
+  - given-names: Vincent
+    family-names: Pollet
+    email: vincent.pollet@lapp.in2p3.fr
+    affiliation: 'LAPP, CNRS'
 repository-code: 'https://github.com/EVERSE-ResearchSoftware/TechRadar/'
 url: 'https://everse.software/TechRadar/'
 abstract: >-

--- a/quality-tools/pixi.json
+++ b/quality-tools/pixi.json
@@ -1,0 +1,47 @@
+{
+  "@context": "https://w3id.org/everse/rs#",
+  "@id": "https://w3id.org/everse/tools/pixi",
+  "@type": "schema:SoftwareApplication",
+  "name": "pixi",
+  "description": "Pixi is a fast, modern, and reproducible package management tool for developers of all backgrounds. It is based on the conda ecosystem and allows creating reproducible software development environments and workflows for all platforms.",
+  "url": "https://pixi.prefix.dev/latest/",
+  "isAccessibleForFree": true,
+  "hasQualityDimension": [
+    {
+      "@id": "dim:compatibility",
+      "@type": "@id"
+    },
+    {
+      "@id": "dim:flexibility",
+      "@type": "@id"
+    },
+    {
+      "@id": "dim:reliability",
+      "@type": "@id"
+    },
+    {
+      "@id": "dim:sustainability",
+      "@type": "@id"
+    },
+    {
+      "@id": "dim:maintainability",
+      "@type": "@id"
+    }
+  ],
+  "applicationCategory": {
+    "@id": "rs:ResearchInfrastructureSoftware",
+    "@type": "@id"
+  },
+  "howToUse": ["CI/CD", "command-line"],
+  "license": "https://spdx.org/licenses/BSD-3-Clause.html",
+  "improvesQualityIndicator": [
+    {
+      "@id": "https://w3id.org/everse/i/indicators/dependency_management",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/requirements_specified",
+      "@type": "@id"
+    }
+  ]
+}


### PR DESCRIPTION
Add [pixi](https://pixi.prefix.dev/latest/) to the tech radar softwares. Pixi is a fast, reproducible better alternative to `conda` and `mamba` to manage conda packages and environments.