### PR TITLE
Issue #212 zenodo-github-integration.json

### DIFF
--- a/quality-tools/zenodo-github-integration.json
+++ b/quality-tools/zenodo-github-integration.json
@@ -6,11 +6,35 @@
   "description": "Zenodo archives your repository and issues a new DOI each time you create a new GitHub release",
   "url": "https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content",
   "isAccessibleForFree": true,
-  "hasQualityDimension": { "@id": "dim:sustainability", "@type": "@id" },
+  "hasQualityDimension": [
+    { "@id": "dim:sustainability", "@type": "@id" },
+    { "@id": "dim:open_source_software", "@type": "@id" },
+    { "@id": "dim:fairness", "@type": "@id" }
+  ],
   "license": "https://spdx.org/licenses/CC-BY-4.0",
   "howToUse": ["CI/CD", "online-service"],
   "applicationCategory": [
     { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id" },
     { "@id": "rs:PrototypeTool", "@type": "@id" }
+  ],
+    "improvesQualityIndicator": [
+    {"@id": "https://w3id.org/everse/i/indicators/project_is_active", 
+    "@type": "@id"},
+
+    {"@id": "https://w3id.org/everse/i/indicators/has_releases", 
+    "@type": "@id"},
+
+    {"@id": "https://w3id.org/everse/i/indicators/persistent_and_unique_identifier", 
+    "@type": "@id"},
+
+    {"@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage", 
+    "@type": "@id"},
+
+    {"@id": "https://w3id.org/everse/i/indicators/archived_in_scholarly_repository", 
+    "@type": "@id"},
+
+    {"@id": "https://w3id.org/everse/i/indicators/listed_in_registry", 
+    "@type": "@id"}
+
   ]
 }

--- a/quality-tools/zenodo-github-integration.json
+++ b/quality-tools/zenodo-github-integration.json
@@ -34,11 +34,6 @@
     },
 
     {
-      "@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage",
-      "@type": "@id"
-    },
-
-    {
       "@id": "https://w3id.org/everse/i/indicators/archived_in_scholarly_repository",
       "@type": "@id"
     },

--- a/quality-tools/zenodo-github-integration.json
+++ b/quality-tools/zenodo-github-integration.json
@@ -17,24 +17,35 @@
     { "@id": "rs:ResearchInfrastructureSoftware", "@type": "@id" },
     { "@id": "rs:PrototypeTool", "@type": "@id" }
   ],
-    "improvesQualityIndicator": [
-    {"@id": "https://w3id.org/everse/i/indicators/project_is_active", 
-    "@type": "@id"},
+  "improvesQualityIndicator": [
+    {
+      "@id": "https://w3id.org/everse/i/indicators/project_is_active",
+      "@type": "@id"
+    },
 
-    {"@id": "https://w3id.org/everse/i/indicators/has_releases", 
-    "@type": "@id"},
+    {
+      "@id": "https://w3id.org/everse/i/indicators/has_releases",
+      "@type": "@id"
+    },
 
-    {"@id": "https://w3id.org/everse/i/indicators/persistent_and_unique_identifier", 
-    "@type": "@id"},
+    {
+      "@id": "https://w3id.org/everse/i/indicators/persistent_and_unique_identifier",
+      "@type": "@id"
+    },
 
-    {"@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage", 
-    "@type": "@id"},
+    {
+      "@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage",
+      "@type": "@id"
+    },
 
-    {"@id": "https://w3id.org/everse/i/indicators/archived_in_scholarly_repository", 
-    "@type": "@id"},
+    {
+      "@id": "https://w3id.org/everse/i/indicators/archived_in_scholarly_repository",
+      "@type": "@id"
+    },
 
-    {"@id": "https://w3id.org/everse/i/indicators/listed_in_registry", 
-    "@type": "@id"}
-
+    {
+      "@id": "https://w3id.org/everse/i/indicators/listed_in_registry",
+      "@type": "@id"
+    }
   ]
 }


### PR DESCRIPTION
Fixes #212

I added: 
- dim:open_source_software, because zenodo persistent identifier can only be issued for public repositories
- dim:fairness
- improvesQualityIndicator: project_is_active
- improvesQualityIndicator: persistent_and_unique_identifier
- improvesQualityIndicator: has_releases
- improvesQualityIndicator: archived_in_software_heritage
- improvesQualityIndicator: archived_in_scholarly_repository
- improvesQualityIndicator: listed_in_registry