### PR TITLE
catalog: update cmake metadata and indicators

### DIFF
--- a/quality-tools/cmake.json
+++ b/quality-tools/cmake.json
@@ -6,7 +6,7 @@
     "@id": "rs:ResearchInfrastructureSoftware",
     "type": "@id"
   },
-  "description": "Cross-platform build system generator that simplifies the build process for research software across different operating systems and compilers, improving software portability and maintainability.",
+  "description": "Cross-platform build system generator that simplifies the build process for research software across different operating systems and compilers, improving software portability and maintainability. Includes CTest for testing and CPack for packaging.",
   "hasQualityDimension": [
     {
       "@id": "dim:maintainability",
@@ -37,6 +37,10 @@
     },
     {
       "@id": "https://w3id.org/everse/i/indicators/uses_tool_for_warnings_and_mistakes",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/has_published_package",
       "@type": "@id"
     }
   ]


### PR DESCRIPTION
## Description
Deep semantic audit for **CMake**.

## Changes
- [x] Updated description / license.
- [x] Added new indicators: `has_published_package`.
- [ ] Removed obsolete indicators: none.

## Justification & Sources
- **Official Source**: https://cmake.org/
- **Rationale**: CMake integrates CTest (for `software_has_tests`), manages dependencies natively (`dependency_management`), specifies build requirements in `CMakeLists.txt` (`requirements_specified`), sets compiler warning flags natively (`uses_tool_for_warnings_and_mistakes`), and provides CPack to create distributable packages (`has_published_package`).