### PR TITLE
catalog: update javadoc metadata and indicators

### DIFF
--- a/quality-tools/javadoc.json
+++ b/quality-tools/javadoc.json
@@ -14,7 +14,7 @@
   ],
   "howToUse": ["CI/CD", "command-line"],
   "isAccessibleForFree": true,
-  "license": "https://www.oracle.com/downloads/licenses/javadoc-updater-license.html",
+  "license": "https://spdx.org/licenses/GPL-2.0-with-classpath-exception",
   "name": "javadoc",
   "url": "https://www.oracle.com/java/technologies/javase/javadoc-tool.html",
   "improvesQualityIndicator": [
@@ -23,7 +23,7 @@
       "@type": "@id"
     },
     {
-      "@id": "https://w3id.org/everse/i/indicators/descriptive_metadata",
+      "@id": "https://w3id.org/everse/i/indicators/code_documentation_coverage_ok",
       "@type": "@id"
     }
   ]


### PR DESCRIPTION
## Description
Deep semantic audit for **Javadoc**.

## Changes
- [x] Updated description / license.
- [x] Added new indicators: `code_documentation_coverage_ok`.
- [ ] Removed obsolete indicators: `<list-ids>`.

## Justification & Sources
- **Official Source**: [https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html](https://docs.oracle.com/en/java/javase/17/docs/specs/javadoc/doc-comment-spec.html)
- **Rationale**: Javadoc is the standard tool for generating API documentation in Java from source code comments. `code_documentation_coverage_ok` is perfectly supported as Javadoc forces developers to structure documentation inside the code, inherently enabling the measurement of documentation coverage.