### PR TITLE
catalog: update fuji metadata and indicators

### DIFF
--- a/quality-tools/fuji.json
+++ b/quality-tools/fuji.json
@@ -13,5 +13,7 @@
   "license": "https://spdx.org/licenses/0BSD",
   "name": "F-UJI",
   "url": "https://github.com/softwaresaved/fuji/",
-  "measuresQualityIndicator": { "@id": "https://w3id.org/everse/i/indicators/software_has_license" }
+  "measuresQualityIndicator": {
+    "@id": "https://w3id.org/everse/i/indicators/software_has_license"
+  }
 }

--- a/quality-tools/fuji.json
+++ b/quality-tools/fuji.json
@@ -12,5 +12,6 @@
   "isAccessibleForFree": true,
   "license": "https://spdx.org/licenses/0BSD",
   "name": "F-UJI",
-  "url": "https://github.com/softwaresaved/fuji/"
+  "url": "https://github.com/softwaresaved/fuji/",
+  "measuresQualityIndicator": { "@id": "https://w3id.org/everse/i/indicators/software_has_license" }
 }


### PR DESCRIPTION
## Description
Deep semantic audit for **F-UJI**.

## Changes
- Updated metadata (added measuresQualityIndicator).

## Justification & Sources
- **Official Source**: https://www.f-uji.net/
- **Rationale**: Added `measuresQualityIndicator` linking to `software_has_license` to accurately reflect that the tool provides licensing information, which is strongly supported by the documentation.