### PR TITLE
[Bug Fix] Fix number of dots per segment

### DIFF
--- a/web/src/components/Radar.jsx
+++ b/web/src/components/Radar.jsx
@@ -97,12 +97,20 @@ const Radar = ({ tools, dimensions, size = 500, onDimClick }) => {
                 ? (Array.isArray(tool.applicationCategory) ? tool.applicationCategory : [tool.applicationCategory])
                 : [];
 
-            let itemTiers = [];
-            if (toolTiers.some(t => t['@id'] === 'rs:PrototypeTool')) itemTiers.push(1);
-            if (toolTiers.some(t => t['@id'] === 'rs:ResearchInfrastructureSoftware')) itemTiers.push(2);
-            if (toolTiers.some(t => t['@id'] === 'rs:AnalysisCode')) itemTiers.push(0);
+            const tierMap = {
+                'rs:AnalysisCode': 0,
+                'rs:PrototypeTool': 1,
+                'rs:ResearchInfrastructureSoftware': 2,
+            };
+            const allTierIndices = toolTiers
+                .map(t => tierMap[t['@id']])
+                .filter(i => i !== undefined);
 
-            if (itemTiers.length === 0) return;
+            if (allTierIndices.length === 0) return;
+
+            // Place tool in its lowest (innermost) applicable tier only,
+            // consistent with the About page description.
+            const itemTiers = [Math.min(...allTierIndices)];
 
             // Determine Dimension(s)
             const toolDims = tool.hasQualityDimension


### PR DESCRIPTION
Fixes #403 

Root Cause: 

The bug is a mismatch between what `Radar.jsx` renders and what the `About` page documents.
e.g 
`resqui` has all three tiers (rs:AnalysisCode, rs:PrototypeTool, rs:ResearchInfrastructureSoftware) and `functional_suitability` as a dimension — so the radar renders 3 dots (one per tier). But when the segment is clicked, Home.jsx's filteredTools correctly returns only 1 tool (since resqui is a single entry). 
**So the dot count and the list count are structurally inconsistent.**
`
As per decision About page says:
`**If a tool applies to multiple tiers, it is placed in the lowest applicable tier.**
but the code places it in all applicable tiers.

Fix applied:
In Radar.jsx, replace the multi-tier push with a single minimum tier. This makes the dot count equal to the tool count per segment, so clicking "Functional Stability" shows 1 tool and 1 dot — consistent with the About page
