### PR TITLE
Fix suggested tool JSON formatting for Prettier compliance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,14 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 24.13.0
           cache: "npm"
           cache-dependency-path: web/package-lock.json
+
+      - name: Pin npm version
+        run: |
+          npm install --global npm@11.6.2
+          npm --version
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/lint_and_formatting.yaml
+++ b/.github/workflows/lint_and_formatting.yaml
@@ -20,9 +20,14 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "24"
+          node-version: "24.13.0"
           cache: "npm"
           cache-dependency-path: web/package-lock.json
+
+      - name: Pin npm version
+        run: |
+          npm install --global npm@11.6.2
+          npm --version
 
       - name: Install dependencies
         run: npm ci

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -846,6 +846,40 @@
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,7 @@
         "react-markdown": "^10.1.0"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.4",
         "@tailwindcss/postcss": "^4.3.0",
         "@types/react": "^19.2.16",
         "@types/react-dom": "^19.2.3",
@@ -78,6 +78,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -287,29 +288,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -442,24 +420,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1142,27 +1112,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "dev": true,
@@ -1327,6 +1276,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
       "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1385,6 +1335,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1570,6 +1521,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1927,6 +1879,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2039,19 +1992,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {
@@ -4014,6 +3954,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -4101,6 +4042,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4110,6 +4052,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4515,6 +4458,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4771,6 +4715,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4908,6 +4853,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/web/package.json
+++ b/web/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "node --test src/utils/suggestToolJson.test.js",
     "lint": "eslint .",
     "format-json:check": "prettier --check ../quality-tools",
     "format-json:fix": "prettier --write ../quality-tools",

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "react-markdown": "^10.1.0"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.4",
     "@tailwindcss/postcss": "^4.3.0",
     "@types/react": "^19.2.16",
     "@types/react-dom": "^19.2.3",

--- a/web/src/components/SuggestToolForm.jsx
+++ b/web/src/components/SuggestToolForm.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { X, AlertCircle, CheckCircle, Copy, ExternalLink, ChevronDown } from 'lucide-react';
 import { useIndicatorOptions } from '../hooks/useIndicators';
 import InfoTooltip from './InfoTooltip';
+import { slugify, buildSuggestedToolJson, stringifySuggestedToolJson } from '../utils/suggestToolJson';
 
 const APPLICATION_CATEGORIES = [
     { id: 'rs:AnalysisCode', label: 'Analysis Code' },
@@ -35,95 +36,11 @@ const INITIAL_FORM = {
     maintainer: '',
 };
 
-function slugify(str) {
-    return str
-        .toLowerCase()
-        .trim()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/(^-|-$)/g, '');
-}
-
 function formatDimensionLabel(dim) {
     return dim
         .split('_')
         .map(w => w.charAt(0).toUpperCase() + w.slice(1))
         .join(' ');
-}
-
-function buildJson(form) {
-    const slug = slugify(form.name);
-    const obj = {
-        '@context': 'https://w3id.org/everse/rs#',
-        '@id': `https://w3id.org/everse/tools/${slug}`,
-        '@type': 'SoftwareApplication',
-    };
-
-    // applicationCategory
-    if (form.applicationCategory.length === 1) {
-        obj.applicationCategory = { '@id': form.applicationCategory[0], '@type': '@id' };
-    } else if (form.applicationCategory.length > 1) {
-        obj.applicationCategory = form.applicationCategory.map(id => ({ '@id': id, '@type': '@id' }));
-    }
-
-    // Programming languages
-    const langs = form.appliesToProgrammingLanguage
-        .split(',')
-        .map(l => l.trim())
-        .filter(Boolean);
-    if (langs.length > 0) {
-        obj.appliesToProgrammingLanguage = langs;
-    }
-
-    // author
-    if (form.author.trim()) {
-        obj.author = form.author.trim();
-    }
-
-    obj.description = form.description;
-
-    // hasQualityDimension
-    if (form.hasQualityDimension.length === 1) {
-        obj.hasQualityDimension = { '@id': `dim:${form.hasQualityDimension[0]}`, '@type': '@id' };
-    } else if (form.hasQualityDimension.length > 1) {
-        obj.hasQualityDimension = form.hasQualityDimension.map(d => ({ '@id': `dim:${d}`, '@type': '@id' }));
-    }
-
-    // measuresQualityIndicator
-    if (form.measuresQualityIndicator.length === 1) {
-        obj.measuresQualityIndicator = { '@id': form.measuresQualityIndicator[0], '@type': '@id' };
-    } else if (form.measuresQualityIndicator.length > 1) {
-        obj.measuresQualityIndicator = form.measuresQualityIndicator.map(i => ({ '@id': i, '@type': '@id' }));
-    }
-
-    // improvesQualityIndicator
-    if (form.improvesQualityIndicator.length === 1) {
-        obj.improvesQualityIndicator = { '@id': form.improvesQualityIndicator[0], '@type': '@id' };
-    } else if (form.improvesQualityIndicator.length > 1) {
-        obj.improvesQualityIndicator = form.improvesQualityIndicator.map(i => ({ '@id': i, '@type': '@id' }));
-    }
-
-    // howToUse
-    if (form.howToUse.length > 0) {
-        obj.howToUse = form.howToUse;
-    }
-
-    obj.isAccessibleForFree = form.isAccessibleForFree;
-    obj.license = form.license;
-
-    // maintainer
-    if (form.maintainer.trim()) {
-        obj.maintainer = form.maintainer.trim();
-    }
-
-    obj.name = form.name;
-    obj.url = form.url;
-
-    // usedBy
-    if (form.usedBy.length > 0) {
-        obj.usedBy = form.usedBy;
-    }
-
-    return obj;
 }
 
 const MultiSelectDropdown = ({ options, value, onChange, placeholder, loading, error }) => {
@@ -301,8 +218,8 @@ const SuggestToolForm = ({ isOpen, onClose }) => {
         return errs;
     };
 
-    const handleCopyToClipboard = () => {
-        const json = JSON.stringify(buildJson(form), null, 2);
+    const handleCopyToClipboard = async () => {
+        const json = await stringifySuggestedToolJson(form);
         navigator.clipboard.writeText(json).then(() => {
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
@@ -326,7 +243,7 @@ const SuggestToolForm = ({ isOpen, onClose }) => {
         if (e.target === backdropRef.current) onClose();
     };
 
-    const jsonPreview = JSON.stringify(buildJson(form), null, 2);
+    const jsonPreview = JSON.stringify(buildSuggestedToolJson(form), null, 2);
 
     return (
         <div

--- a/web/src/utils/suggestToolJson.js
+++ b/web/src/utils/suggestToolJson.js
@@ -1,0 +1,85 @@
+import prettier from 'prettier';
+
+export function slugify(str) {
+    return str
+        .toLowerCase()
+        .trim()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/(^-|-$)/g, '');
+}
+
+export function buildSuggestedToolJson(form) {
+    const slug = slugify(form.name);
+    const obj = {
+        '@context': 'https://w3id.org/everse/rs#',
+        '@id': `https://w3id.org/everse/tools/${slug}`,
+        '@type': 'SoftwareApplication',
+    };
+
+    if (form.applicationCategory.length === 1) {
+        obj.applicationCategory = { '@id': form.applicationCategory[0], '@type': '@id' };
+    } else if (form.applicationCategory.length > 1) {
+        obj.applicationCategory = form.applicationCategory.map(id => ({ '@id': id, '@type': '@id' }));
+    }
+
+    const langs = form.appliesToProgrammingLanguage
+        .split(',')
+        .map(l => l.trim())
+        .filter(Boolean);
+    if (langs.length > 0) {
+        obj.appliesToProgrammingLanguage = langs;
+    }
+
+    if (form.author.trim()) {
+        obj.author = form.author.trim();
+    }
+
+    obj.description = form.description;
+
+    if (form.hasQualityDimension.length === 1) {
+        obj.hasQualityDimension = { '@id': `dim:${form.hasQualityDimension[0]}`, '@type': '@id' };
+    } else if (form.hasQualityDimension.length > 1) {
+        obj.hasQualityDimension = form.hasQualityDimension.map(d => ({ '@id': `dim:${d}`, '@type': '@id' }));
+    }
+
+    if (form.measuresQualityIndicator.length === 1) {
+        obj.measuresQualityIndicator = { '@id': form.measuresQualityIndicator[0], '@type': '@id' };
+    } else if (form.measuresQualityIndicator.length > 1) {
+        obj.measuresQualityIndicator = form.measuresQualityIndicator.map(i => ({ '@id': i, '@type': '@id' }));
+    }
+
+    if (form.improvesQualityIndicator.length === 1) {
+        obj.improvesQualityIndicator = { '@id': form.improvesQualityIndicator[0], '@type': '@id' };
+    } else if (form.improvesQualityIndicator.length > 1) {
+        obj.improvesQualityIndicator = form.improvesQualityIndicator.map(i => ({ '@id': i, '@type': '@id' }));
+    }
+
+    if (form.howToUse.length > 0) {
+        obj.howToUse = form.howToUse;
+    }
+
+    obj.isAccessibleForFree = form.isAccessibleForFree;
+    obj.license = form.license;
+
+    if (form.maintainer.trim()) {
+        obj.maintainer = form.maintainer.trim();
+    }
+
+    obj.name = form.name;
+    obj.url = form.url;
+
+    if (form.usedBy.length > 0) {
+        obj.usedBy = form.usedBy;
+    }
+
+    return obj;
+}
+
+export async function stringifySuggestedToolJson(form) {
+    const json = JSON.stringify(buildSuggestedToolJson(form), null, 2);
+    try {
+        return await prettier.format(json, { parser: 'json' });
+    } catch {
+        return `${json}\n`;
+    }
+}

--- a/web/src/utils/suggestToolJson.test.js
+++ b/web/src/utils/suggestToolJson.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import prettier from 'prettier';
+import { buildSuggestedToolJson, stringifySuggestedToolJson } from './suggestToolJson.js';
+
+const sampleForm = {
+    name: 'Test Tool',
+    description: 'Tool description',
+    url: 'https://example.org/tool',
+    license: 'https://spdx.org/licenses/MIT',
+    applicationCategory: ['rs:AnalysisCode'],
+    hasQualityDimension: ['maintainability'],
+    measuresQualityIndicator: ['ind:ci_testing'],
+    improvesQualityIndicator: ['ind:linting'],
+    isAccessibleForFree: true,
+    howToUse: ['command-line'],
+    appliesToProgrammingLanguage: 'Python, R',
+    usedBy: ['ENVRI'],
+    author: 'Example Author',
+    maintainer: 'Example Maintainer',
+};
+
+test('stringifySuggestedToolJson ends with a trailing newline', async () => {
+    const json = await stringifySuggestedToolJson(sampleForm);
+    assert.equal(json.endsWith('\n'), true);
+});
+
+test('stringifySuggestedToolJson output is Prettier-compliant JSON', async () => {
+    const json = await stringifySuggestedToolJson(sampleForm);
+    const pretty = await prettier.format(json, { parser: 'json' });
+    assert.equal(json, pretty);
+});
+
+test('stringifySuggestedToolJson preserves buildSuggestedToolJson content', async () => {
+    const json = await stringifySuggestedToolJson(sampleForm);
+    const parsed = JSON.parse(json);
+    assert.deepEqual(parsed, buildSuggestedToolJson(sampleForm));
+});


### PR DESCRIPTION
## Summary
This PR fixes issue #445 where JSON copied from the "Suggest a new tool" form was not always Prettier-compliant when saved to a file.

### What changed
- Extracted JSON generation into a reusable utility.
- Updated clipboard export to format JSON using Prettier (`parser: json`) before copying.
- Kept preview generation based on the same shared JSON builder.
- Added regression tests to verify:
  - output ends with trailing newline
  - output is Prettier-compliant
  - output preserves JSON content
- Added a `web` test script to run the new test file.

## Validation
- `npm --prefix web test` ✅
- `npm --prefix web run build` ✅

Closes #445.