### PR TITLE
Add indicators for fair_python_cookiecutter

### DIFF
--- a/quality-tools/fair-python-cookiecutter.json
+++ b/quality-tools/fair-python-cookiecutter.json
@@ -10,5 +10,43 @@
   "isAccessibleForFree": true,
   "license": "https://spdx.org/licenses/MIT",
   "name": "Fair Python Cookiecutter",
-  "url": "https://github.com/Materials-Data-Science-and-Informatics/fair-python-cookiecutter"
+  "url": "https://github.com/Materials-Data-Science-and-Informatics/fair-python-cookiecutter",
+  "improvesQualityIndicator": [
+    {
+      "@id": "https://w3id.org/everse/i/indicators/software_has_license",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/software_has_license_for_file_types",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/software_has_citation",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/descriptive_metadata",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/requirements_specified",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/software_has_documentation",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/repository_workflows",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/software_has_tests",
+      "@type": "@id"
+    },
+    {
+      "@id": "https://w3id.org/everse/i/indicators/has_contribution_guidelines",
+      "@type": "@id"
+    }
+  ]
 }


### PR DESCRIPTION
Fixes #169 

Adds improvesQualityIndicator for fair_python_cookiecutter.

Reasoning for each indicator:
- software_has_license — the template generates a LICENSE file as part of the project scaffold
- software_has_license_for_file_types — the template sets up REUSE.toml which is the REUSE specification for licensing different file types
- software_has_citation — the template generates a CITATION.cff file automatically
- descriptive_metadata — the template generates a codemeta.json with descriptive FAIR metadata
- requirements_specified — the template uses pyproject.toml to formally specify requirements
- software_has_documentation — the template generates a README and documentation infrastructure
- repository_workflows — the template includes pre-configured GitHub Actions workflow files
- software_has_tests — the template scaffolds a test directory and testing setup
- has_contribution_guidelines — the template generates contribution guidelines as part of the project structure