### PR TITLE
docs: document the deployed tools API

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ New versions of the TechRadar will be published regularly. You can find all the 
 
 The catalogue of tools and services is presented in a visual dashboard at [https://everse.software/TechRadar/](https://everse.software/TechRadar/).
 
+### API
+
+The full catalogue is also published online as a machine-readable JSON API, generated from the same [tools and services data](quality-tools) as the dashboard:
+
+[https://everse.software/TechRadar/api/tools.json](https://everse.software/TechRadar/api/tools.json)
+
+It is regenerated and redeployed automatically whenever the catalogue changes on `main`, so it always reflects the current dashboard content.
+
 ### Development
 
 All developer setup, run, lint, build, formatting, and validation instructions are documented in [web/README.md](web/README.md).

--- a/web/README.md
+++ b/web/README.md
@@ -70,11 +70,12 @@ This means:
 
 The build process also creates a static aggregated API payload from all files in `../quality-tools`:
 
-- Build artifact path: `dist/api/tools.json`
-- URL on deployed docs site: `.../api/tools.json`
+- Generator script: `scripts/generate-tools-api.mjs` (run via `npm run build:api`, and automatically as part of `npm run build`)
+- Build artifact path: `dist/api/tools.json` (source is written to `public/api/tools.json`, which Vite copies into `dist/` as-is)
+- Deployed URL: [https://everse.software/TechRadar/api/tools.json](https://everse.software/TechRadar/api/tools.json)
 - Payload keys: `generatedAt`, `source`, `count`, `files`, `tools`
 
-Because this file is generated during `npm run build`, the deployed docs always include an up-to-date machine-readable API of the catalogue.
+Because this file is generated during `npm run build`, and `main` is rebuilt/redeployed by `.github/workflows/deploy.yml` on every push, the deployed docs always include an up-to-date machine-readable API of the catalogue. A separate `.github/workflows/build-tools-api.yml` workflow also regenerates and uploads `tools.json` as a CI artifact on every push to `main`, independent of the Pages deploy.
 
 ## Styling System
 


### PR DESCRIPTION
## Summary
- Root `README.md`: added an "API" section pointing readers to the live, machine-readable catalogue endpoint `https://everse.software/TechRadar/api/tools.json` (generated by the `apitools` feature already merged into `main`).
- `web/README.md`: expanded the existing "Aggregated JSON API" section for developers with the generator script location, how the artifact flows from `public/api/tools.json` into `dist/`, the concrete deployed URL, and how it's kept fresh (`deploy.yml` on every push to `main`, plus the separate `build-tools-api.yml` CI artifact workflow).

## Test plan
- [x] Verified the referenced files/workflows (`web/scripts/generate-tools-api.mjs`, `build-tools-api.yml`, `deploy.yml`) exist on `main`
- [ ] Docs-only change, no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)