### PR TITLE
Renamed software tier filters

### DIFF
--- a/quality-tools/somef-vider.json
+++ b/quality-tools/somef-vider.json
@@ -12,7 +12,7 @@
   "isAccessibleForFree": true,
   "license": "https://spdx.org/licenses/MIT",
   "name": "SOMEF-Vider",
-  "url": "https://somef.linkeddata.es/",
+  "url": "https://github.com/SoftwareUnderstanding/SOMEF-Vider/",
   "measuresQualityIndicator": [
     {
       "@id": "https://w3id.org/everse/i/indicators/software_has_license",

--- a/web/src/components/FilterSidebar.jsx
+++ b/web/src/components/FilterSidebar.jsx
@@ -65,7 +65,7 @@ const FilterSidebar = ({ options, filters, onFilterChange, onClear }) => {
 
                 <div className="mb-6 border-b border-slate-200 pb-6">
                     <div className="flex items-center justify-between mb-4">
-                        <h3 className="font-semibold text-slate-700">Your software's targets</h3>
+                        <h3 className="font-semibold text-slate-700">Your software's type</h3>
                         <a
                             href="https://everse.software/RSQKit/three_tier_view"
                             target="_blank"
@@ -79,9 +79,9 @@ const FilterSidebar = ({ options, filters, onFilterChange, onClear }) => {
                         <div className="relative flex flex-col gap-4 w-full">
                             {['ResearchInfrastructureSoftware', 'PrototypeTool', 'AnalysisCode'].map((cat, index, arr) => {
                                 const mapping = {
-                                    'AnalysisCode': 'individuals',
-                                    'PrototypeTool': 'research teams',
-                                    'ResearchInfrastructureSoftware': 'communities'
+                                    'AnalysisCode': 'Analysis Code',
+                                    'PrototypeTool': 'Prototype Tool',
+                                    'ResearchInfrastructureSoftware': 'Research Infrastructure Software'
                                 };
                                 const isActive = filters.categories.includes(cat);
                                 const isLast = index === arr.length - 1;

--- a/web/src/components/Radar.jsx
+++ b/web/src/components/Radar.jsx
@@ -35,11 +35,10 @@ const Radar = ({ tools, dimensions, size = 500, onDimClick }) => {
     const radius = size / 2 - 100; // Padding for labels
 
     // Tier Configuration
-    // Labels: individuals, research teams, communities (hidden but kept for layout logic)
     const tiers = useMemo(() => [
-        { id: 'rs:AnalysisCode', label: 'individuals', radiusRatio: 0.33 },
-        { id: 'rs:PrototypeTool', label: 'research teams', radiusRatio: 0.66 },
-        { id: 'rs:ResearchInfrastructureSoftware', label: 'communities', radiusRatio: 1.0 }
+        { id: 'rs:AnalysisCode', label: 'Analysis Code', radiusRatio: 0.33 },
+        { id: 'rs:PrototypeTool', label: 'Prototype Tool', radiusRatio: 0.66 },
+        { id: 'rs:ResearchInfrastructureSoftware', label: 'Research Infrastructure Software', radiusRatio: 1.0 }
     ], []);
 
     // Helper to get coordinates


### PR DESCRIPTION

TECHNICAL DEVELOPMENT


**Describe the proposed development**
This is to fix issue #405 

**Purpose of the development**
Small change - This is coming as a suggestion to keep Software tier filter labels on TR UI exactly same as three-tier model - to ease user experience. And not to confuse with filter labels



