### PR TITLE
ci: exclude softwareheritage.org from link check

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -6,6 +6,8 @@ exclude = [
   "^https://www\\.doxygen\\.nl/?$",
   "https://github.com/customer-terms/github-copilot-product-specific-terms",
   "https://sylabs.io/singularity/",
+  # Trusted site; its certificate chain is not in lychee's bundled root store.
+  "^https://www\\.softwareheritage\\.org",
 ]
 
 max_redirects = 10


### PR DESCRIPTION
The SWH certificate chain is not in lychee's bundled root store, so CI reports "SSL certificate not trusted" for https://www.softwareheritage.org in quality-tools/software-heritage.json. The site is trusted and resolves fine against the system trust store.

Scoped to the SWH host rather than setting insecure = true, which would disable TLS verification for every checked link.


Claude-Session: https://claude.ai/code/session_01VvSf3BGib527mE2ecJ2c9Z

